### PR TITLE
Add region to Office

### DIFF
--- a/app/dashboards/office_dashboard.rb
+++ b/app/dashboards/office_dashboard.rb
@@ -25,6 +25,7 @@ class OfficeDashboard < Administrate::BaseDashboard
     :id,
     :name,
     :region,
+    :address,
     :created_at
   ].freeze
 

--- a/app/dashboards/office_dashboard.rb
+++ b/app/dashboards/office_dashboard.rb
@@ -11,6 +11,7 @@ class OfficeDashboard < Administrate::BaseDashboard
     address: AddressField,
     id: Field::Number,
     name: Field::String,
+    region: Field::Number,
     created_at: Field::DateTime,
     updated_at: Field::DateTime
   }.freeze
@@ -23,6 +24,7 @@ class OfficeDashboard < Administrate::BaseDashboard
   COLLECTION_ATTRIBUTES = [
     :id,
     :name,
+    :region,
     :created_at
   ].freeze
 
@@ -30,6 +32,7 @@ class OfficeDashboard < Administrate::BaseDashboard
   # an array of attributes that will be displayed on the model's show page.
   SHOW_PAGE_ATTRIBUTES = [
     :name,
+    :region,
     :address,
     :id,
     :created_at,
@@ -41,6 +44,7 @@ class OfficeDashboard < Administrate::BaseDashboard
   # on the model's form (`new` and `edit`) pages.
   FORM_ATTRIBUTES = [
     :name,
+    :region,
     :address
   ].freeze
 

--- a/app/dashboards/office_dashboard.rb
+++ b/app/dashboards/office_dashboard.rb
@@ -53,6 +53,6 @@ class OfficeDashboard < Administrate::BaseDashboard
   # across all pages of the admin dashboard.
   #
   def display_resource(office)
-    office.name
+    "#{office.name} | #{office.address.state} | Region: #{office.region}"
   end
 end

--- a/app/dashboards/user_dashboard.rb
+++ b/app/dashboards/user_dashboard.rb
@@ -46,6 +46,7 @@ class UserDashboard < Administrate::BaseDashboard
   # Feel free to add, remove, or rearrange items.
   COLLECTION_ATTRIBUTES = [
     :email,
+    :offices,
     :id
   ].freeze
 

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -14,6 +14,6 @@ module ApplicationHelper
   end
 
   def offices_for_select(scope)
-    scope.offices.map { |o| [o.name, o.id] }
+    scope.offices.map { |o| ["#{o.name} | #{o.address.state} | Region: #{o.region}", o.id] }
   end
 end

--- a/app/models/address.rb
+++ b/app/models/address.rb
@@ -2,4 +2,8 @@ class Address < ApplicationRecord
   belongs_to :addressable, polymorphic: true
   validates :street, :city, :state, :postal_code, presence: true
   validates_address geocode: true, fields: %i[street street2 city state postal_code]
+
+  def to_s
+    [street, street2, city, state, postal_code].compact.join(' ')
+  end
 end

--- a/app/models/office.rb
+++ b/app/models/office.rb
@@ -2,6 +2,7 @@ class Office < ApplicationRecord
   has_one :address, as: :addressable
   has_and_belongs_to_many :users
   validates :name, :address, presence: true
+  validates :region, numericality: { only_integer: true }
 
   accepts_nested_attributes_for :address, update_only: true
 end

--- a/app/policies/office_policy.rb
+++ b/app/policies/office_policy.rb
@@ -1,5 +1,5 @@
 class OfficePolicy < ApplicationPolicy
   def permitted_attributes
-    [:name, { address_attributes: %i[street street2 city state postal_code] }]
+    [:name, :region, { address_attributes: %i[street street2 city state postal_code] }]
   end
 end

--- a/app/views/fields/address_field/_index.html.haml
+++ b/app/views/fields/address_field/_index.html.haml
@@ -1,0 +1,1 @@
+= field.data

--- a/db/migrate/20181216033319_add_region_to_offices.rb
+++ b/db/migrate/20181216033319_add_region_to_offices.rb
@@ -1,0 +1,5 @@
+class AddRegionToOffices < ActiveRecord::Migration[5.2]
+  def change
+    add_column :offices, :region, :integer, default: 0, null: false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2018_12_12_062911) do
+ActiveRecord::Schema.define(version: 2018_12_16_033319) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -34,6 +34,7 @@ ActiveRecord::Schema.define(version: 2018_12_12_062911) do
     t.string "name"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.integer "region", default: 0, null: false
   end
 
   create_table "offices_users", id: false, force: :cascade do |t|

--- a/spec/factories/offices.rb
+++ b/spec/factories/offices.rb
@@ -1,6 +1,7 @@
 FactoryBot.define do
   factory :office do
     name { "Vancouver Office" }
+    region { 1 }
     after :build do |office|
       office.address = build(:address, addressable: office)
     end

--- a/spec/helpers/application_helper_spec.rb
+++ b/spec/helpers/application_helper_spec.rb
@@ -16,4 +16,10 @@ RSpec.describe ApplicationHelper, type: :helper do
       end
     end
   end
+
+  describe '#offices_for_select' do
+    it 'returns a string' do
+      expect(helper.offices_for_select(build :user)).to include(include("Vancouver Office | WA | Region: 1"))
+    end
+  end
 end

--- a/spec/models/address_spec.rb
+++ b/spec/models/address_spec.rb
@@ -6,4 +6,10 @@ RSpec.describe Address, type: :model do
   it 'has a valid factory' do
     expect(address.valid?).to be(true)
   end
+
+  describe '#to_s' do
+    it 'returns the full address as a string' do
+      expect(address.to_s).to eq('1901 Main St Vancouver WA 98660')
+    end
+  end
 end

--- a/spec/requests/admin/admin_users_spec.rb
+++ b/spec/requests/admin/admin_users_spec.rb
@@ -29,7 +29,7 @@ RSpec.describe "Admin users spec", type: :request do
 
     it 'has a 200 response' do
       get admin_user_path(user)
-      expect(response).to be_success
+      expect(response).to be_successful
     end
 
     it 'displays the users email' do


### PR DESCRIPTION
Related: #10

Adds region to Office as an integer. Defaults to 0 which will be used as 'default/no region'.

Also adds state & region to the office select box when inviting a new user.