### PR TITLE
Add WebpackDevServer Container

### DIFF
--- a/config/webpacker.yml
+++ b/config/webpacker.yml
@@ -34,9 +34,9 @@ development:
   # Reference: https://webpack.js.org/configuration/dev-server/
   dev_server:
     https: false
-    host: localhost
+    host: 0.0.0.0
     port: 3035
-    public: localhost:3035
+    public: 0.0.0.0:3035
     hmr: false
     # Inline should be set to true if using HMR
     inline: true

--- a/dev-entrypoint
+++ b/dev-entrypoint
@@ -37,15 +37,15 @@ then
   # project's app containers will try to install gems and setup the
   # database concurrently:
   lock_setup
-  # 8: Check if gems need to be installed and install them
+  # 8: Check if dependencies need to be installed and install them
   bundle check || bundle install
+
+  yarn install
   # 9: Setup the database if it doesn't
   if ! rake db:version
   then
     rake db:setup
   fi
-  # 10: Check if yarn needs to install
-  yarn install
   # Start mailcatcher
   mailcatcher --http-ip 0.0.0.0
   # 10: 'Unlock' the setup process:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,4 +1,4 @@
-version: '3.1'
+version: '3'
 services:
   app:
     build: .
@@ -14,6 +14,17 @@ services:
     entrypoint: /app/dev-entrypoint
     tty: true
     stdin_open: true
+    environment:
+      - WEBPACKER_DEV_SERVER_HOST=webpacker
+  webpacker:
+    build: .
+    command: ./bin/webpack-dev-server
+    volumes:
+      - .:/app
+      - gems:/gems
+    ports:
+      - "3035"
+    entrypoint: /app/docker/webpack-entrypoint
   postgres:
     image: postgres:9.6
     ports:

--- a/docker/webpack-entrypoint
+++ b/docker/webpack-entrypoint
@@ -1,0 +1,11 @@
+#!/bin/bash
+
+set -e
+
+until nc -vz app 3000; do
+  echo "App has not started, sleeping..."
+  sleep 1
+done
+echo "Starting Webpacker"
+
+exec "$@"


### PR DESCRIPTION
This PR adds a container running the `webpack-dev-server` for live compiling of modules and assets. It also fixes a minor setup issues with node_modules.

Please verify this does not blow up your dev env before merging.