### PR TITLE
Alter text shown when a language isn't specified

### DIFF
--- a/app/models/null_objects/null_language.rb
+++ b/app/models/null_objects/null_language.rb
@@ -2,6 +2,6 @@
 
 class NullLanguage
   def name
-    'None'
+    'Not specified'
   end
 end

--- a/spec/models/null_objects/null_language_spec.rb
+++ b/spec/models/null_objects/null_language_spec.rb
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe NullLanguage, type: :model do
+
+  let(:object) { described_class.new }
+
+  describe '#name' do
+    it 'returns a value' do
+      expect(object.name).to eq('Not specified')
+    end
+  end
+end


### PR DESCRIPTION
Addresses #71 by changing the text shown if a language isn't specified from "None" to "Not specified".