### PR TITLE
Require age_ranges when need created

### DIFF
--- a/app/models/need.rb
+++ b/app/models/need.rb
@@ -10,7 +10,7 @@ class Need < ApplicationRecord
   has_many :shifts, dependent: :destroy
   has_many :users, through: :shifts
 
-  validates :start_at, :expected_duration, :number_of_children, presence: true
+  validates :age_ranges, :start_at, :expected_duration, :number_of_children, presence: true
   validates :expected_duration, inclusion: { in: ->(need) { (60..) }, message: 'must be at least on hour' }
 
   scope :current, -> { where('start_at > ?', Time.zone.now) }

--- a/app/views/needs/show.html.haml
+++ b/app/views/needs/show.html.haml
@@ -10,11 +10,6 @@
   .cell.small-12.medium-8.large-6
     .grid-x.grid-padding-y.align-middle
       .cell.small-5
-        %div Number of Children
-      .cell.small-7.text-center
-        %strong= @need.number_of_children
-    .grid-x.grid-padding-y.align-middle
-      .cell.small-5
         %div Start Time
       .cell.small-7.text-center
         %strong= @need.start_at.strftime('%l:%M%P')
@@ -25,6 +20,16 @@
         %div Office
       .cell.small-7.text-center
         %strong= @need.office.name
+    .grid-x.grid-padding-y.align-middle
+      .cell.small-5
+        %div Number of Children
+      .cell.small-7.text-center
+        %strong= @need.number_of_children
+    .grid-x.grid-padding-y.align-middle
+      .cell.small-5
+        %div Age Range(s)
+      .cell.small-7.text-center
+        %strong= @need.age_ranges.join(', ')
     .grid-x.grid-padding-y.align-middle
       .cell.small-5
         %div Preferred Language

--- a/spec/factories/needs.rb
+++ b/spec/factories/needs.rb
@@ -7,7 +7,10 @@ FactoryBot.define do
     start_at { Time.zone.now }
     expected_duration { 120 }
     number_of_children { 1 }
-    age_ranges { [build(:age_range)] }
+
+    after(:build) do |need|
+      need.age_ranges << build(:age_range)
+    end
 
     factory :need_with_shifts do
       transient do

--- a/spec/factories/needs.rb
+++ b/spec/factories/needs.rb
@@ -7,6 +7,7 @@ FactoryBot.define do
     start_at { Time.zone.now }
     expected_duration { 120 }
     number_of_children { 1 }
+    age_ranges { [build(:age_range)] }
 
     factory :need_with_shifts do
       transient do

--- a/spec/lib/services/need_notifications/create_spec.rb
+++ b/spec/lib/services/need_notifications/create_spec.rb
@@ -25,7 +25,8 @@ RSpec.describe Services::NeedNotifications::Create do
 
   context 'with multiple users' do
     it 'returns volunteers notified' do
-      need.office.users << users = build_list(:user, 2)
+      users = build_list(:user, 2, age_ranges: need.age_ranges)
+      need.office.users << users
       expect(subject).to include(*users)
     end
   end
@@ -51,7 +52,9 @@ RSpec.describe Services::NeedNotifications::Create do
 
   context 'preferred language was specified' do
     let(:language) { build(:language, name: 'gibberish') }
-    let(:language_speaking_user) { build(:user, first_language: language) }
+    let(:language_speaking_user) do
+      build(:user, first_language: language, age_ranges: need.age_ranges)
+    end
 
     before do
       need.update(preferred_language: language)

--- a/spec/lib/services/need_notifications/update_spec.rb
+++ b/spec/lib/services/need_notifications/update_spec.rb
@@ -25,7 +25,8 @@ RSpec.describe Services::NeedNotifications::Update do
 
   context 'with multiple users' do
     it 'returns volunteers notified' do
-      need.office.users << users = build_list(:user, 2)
+      users = build_list(:user, 2, age_ranges: need.age_ranges)
+      need.office.users << users
       expect(subject).to include(*users)
     end
   end
@@ -51,7 +52,9 @@ RSpec.describe Services::NeedNotifications::Update do
 
   context 'preferred language was specified' do
     let(:language) { build(:language, name: 'gibberish') }
-    let(:language_speaking_user) { build(:user, first_language: language) }
+    let(:language_speaking_user) do
+      build(:user, first_language: language, age_ranges: need.age_ranges)
+    end
 
     before do
       need.update(preferred_language: language)

--- a/spec/lib/services/shift_notifications/create_spec.rb
+++ b/spec/lib/services/shift_notifications/create_spec.rb
@@ -4,6 +4,7 @@ require 'rails_helper'
 
 RSpec.describe Services::ShiftNotifications::Create do
   let(:shift) { create(:need_with_shifts).shifts.first }
+  let(:need) { shift.need }
 
   let(:user) { create(:user) }
 
@@ -21,7 +22,8 @@ RSpec.describe Services::ShiftNotifications::Create do
 
   context 'with multiple users' do
     it 'returns volunteers notified' do
-      shift.need.office.users << users = build_list(:user, 2)
+      users = build_list(:user, 2, age_ranges: need.age_ranges)
+      need.office.users << users
       expect(subject).to include(*users)
     end
   end
@@ -47,7 +49,9 @@ RSpec.describe Services::ShiftNotifications::Create do
 
   context 'preferred language was specified' do
     let(:language) { create(:language, name: 'gibberish') }
-    let(:language_speaking_user) { create(:user, first_language: language) }
+    let(:language_speaking_user) do
+      create(:user, first_language: language, age_ranges: need.age_ranges)
+    end
 
     before do
       shift.need.update(preferred_language: language)

--- a/spec/requests/needs_spec.rb
+++ b/spec/requests/needs_spec.rb
@@ -35,10 +35,16 @@ RSpec.describe "Needs", type: :request do
 
   describe '#create' do
     context 'success' do
+      let(:params) do
+        {
+          need: attributes_for(:need).merge(office_id:     need.office_id,
+                                            age_range_ids: [AgeRange.first.id])
+        }
+      end
       it 'is redirects to the need' do
         expect(Services::BuildNeedShifts).to receive(:call).and_return([]).once
         expect(Services::NeedNotifications::Create).to receive(:call).and_return(true).once
-        post needs_path, params: { need: attributes_for(:need).merge(office_id: need.office_id) }
+        post needs_path, params: params
         expect(response).to redirect_to(assigns(:need))
       end
     end


### PR DESCRIPTION
Addresses #81 by requiring an age range to be present when a need is created. Also adds the display of age ranges to `Needs#show` and rearranges the order of fields shown on that page (Nate agreed).