### PR TITLE
Show effective need start at; dont allow creating shifts in the past

### DIFF
--- a/app/models/need.rb
+++ b/app/models/need.rb
@@ -28,4 +28,8 @@ class Need < ApplicationRecord
   def expired?
     end_at <= Time.zone.now
   end
+
+  def effective_start_at
+    [start_at, *shifts.pluck(:start_at)].min
+  end
 end

--- a/app/views/needs/show.html.haml
+++ b/app/views/needs/show.html.haml
@@ -1,5 +1,5 @@
 - content_for :page_header do
-  .header-text Need at #{@need.start_at.strftime('%l:%M%P on %A, %b %d')}
+  .header-text Need at #{@need.effective_start_at.strftime('%l:%M%P on %A, %b %d')}
 - if policy(@need).edit? && !@need.expired?
   - content_for :nav_buttons do
     = link_to 'Manage Shifts', need_shifts_path(@need), class: 'button primary'
@@ -17,7 +17,7 @@
       .cell.small-5
         %div Start Time
       .cell.small-7.text-center
-        %strong= @need.start_at.strftime('%l:%M%P')
+        %strong= @need.effective_start_at.strftime('%l:%M%P')
         %br
         = @need.start_at.strftime('%A, %b %d')
     .grid-x.grid-padding-y.align-middle

--- a/app/views/shifts/_manage_shifts.html.haml
+++ b/app/views/shifts/_manage_shifts.html.haml
@@ -1,10 +1,11 @@
-= link_to need_shifts_path(@need, shift: { start_at: shifts.first.start_at - 1.hour, duration: 60 }), method: :post do
-  .grid-x.grid-margin-y.grid-margin-x
-    .cell.small-12.medium-6.shift.add-shift
-      .grid-x.grid-padding-x.grid-padding-y
-        .cell.text-center
-          %i.fas.fa-plus
-          Add Shift Before
+- if shifts.first.start_at.advance(hours: -1) > Time.zone.now
+  = link_to need_shifts_path(@need, shift: { start_at: shifts.first.start_at - 1.hour, duration: 60 }), method: :post do
+    .grid-x.grid-margin-y.grid-margin-x
+      .cell.small-12.medium-6.shift.add-shift
+        .grid-x.grid-padding-x.grid-padding-y
+          .cell.text-center
+            %i.fas.fa-plus
+            Add Shift Before
 - shifts.each_with_index do |shift, i|
   %hr
   .grid-x.grid-margin-y.grid-margin-x.align-spaced.align-middle

--- a/spec/models/need_spec.rb
+++ b/spec/models/need_spec.rb
@@ -8,4 +8,30 @@ RSpec.describe Need, type: :model do
   it 'has a valid factory' do
     expect(need.valid?).to be(true)
   end
+
+  describe '#effective_start_at' do
+    it 'returns need start at if no shifts' do
+      result = need.effective_start_at
+
+      expect(result).to eql(need.start_at)
+    end
+
+    it 'returns need start at if no shifts are earlier' do
+      need.shifts << build(:shift, start_at: need.start_at)
+
+      result = need.effective_start_at
+
+      expect(result).to eql(need.start_at)
+    end
+
+    it 'returns earliest shift start at if earlier than need start at' do
+      starts = need.start_at.advance(hours: -1)
+      need.shifts << build(:shift, start_at: starts)
+      need.save!
+
+      result = need.effective_start_at
+
+      expect(result).to eql(starts)
+    end
+  end
 end


### PR DESCRIPTION
Addresses #69 and #77 by:
- preventing users from creating a new shift in the past
- displaying the effective start time of a need (show start time of earliest shift if it occurs before the start time of the need)