### PR TITLE
Add link back to application from admin

### DIFF
--- a/app/views/admin/application/_navigation.html.erb
+++ b/app/views/admin/application/_navigation.html.erb
@@ -1,0 +1,19 @@
+<%#
+# Navigation
+
+This partial is used to display the navigation in Administrate.
+By default, the navigation contains navigation links
+for all resources in the admin dashboard,
+as defined by the routes in the `admin/` namespace
+%>
+
+<nav class="navigation" role="navigation">
+  <%= link_to 'Application', root_path, class: 'navigation__link navigation__link--inactive' %>
+  <% Administrate::Namespace.new(namespace).resources.each do |resource| %>
+    <%= link_to(
+      display_resource_name(resource),
+      [namespace, resource_index_route_key(resource)],
+      class: "navigation__link navigation__link--#{nav_link_state(resource)}"
+    ) %>
+  <% end %>
+</nav>


### PR DESCRIPTION
Addresses #67 by adding a link back to the application to the admin nav. I generated this view partial via `rails generate administrate:views:navigation`.

Also, wasn't sure what was desired for link text, so went with "Application". More than happy to change that.