### PR TITLE
Fix blockout time datepicker for hour blocks

### DIFF
--- a/app/javascript/components/blockouts/DateTimePicker/index.js
+++ b/app/javascript/components/blockouts/DateTimePicker/index.js
@@ -51,7 +51,7 @@ class DateTimePicker extends React.Component {
   toggleAllDay = _ => {
     const { state: { allDay, fromDate, toDate } } = this
     if (allDay) {
-      this.setState(state => ({ allDay: false, toDate: (toDate || fromDate) }))
+      this.setState(state => ({ allDay: false, toDate: toDate }))
     } else {
       this.setState(state => ({ allDay: true, fromTime: '00:00', toTime: '23:59' }), this.computeResult)
     }


### PR DESCRIPTION
Allow users to move start date forward when setting a blockout for a time slot on a single day.

The datepicker was not able to advance start date past the end date. This allows that. Possible further work could be to remove the end date altogether, but I suppose this allows for a blockout to be for a timespan that covers midnight.