### PR TITLE
Add release to procfile for running migration

### DIFF
--- a/Procfile
+++ b/Procfile
@@ -1,2 +1,3 @@
 web: bundle exec puma -C config/puma.rb
 worker: bundle exec sidekiq -e $RAILS_ENV -C config/sidekiq.yml
+release: bundle exec rails db:migrate


### PR DESCRIPTION
This uses the release feature to run migrations before the app server comes up.