### PR TITLE
More detailed text message notifications

### DIFF
--- a/app/lib/services/shift_notifications/update.rb
+++ b/app/lib/services/shift_notifications/update.rb
@@ -18,6 +18,7 @@ module Services
       def call
         send_confirmation if current_user == user && user
         notification_hash[:users].each do |notified_user|
+          puts notification_hash[:message]
           SendTextMessageWorker.perform_async(notified_user.phone, [notification_hash[:message], need_url(need)].join(' '))
         end
       end
@@ -39,10 +40,10 @@ module Services
       def notification_hash
         if current_user == user && user
           { users: (need.office.users.social_workers | [need.user]),
-            message: "A Volunteer has taken the shift #{starting_day} from #{shift_duration_in_words}." }
+            message: "#{user.first_name} #{user.last_name} has taken the shift #{starting_day} from #{shift_duration_in_words}." }
         elsif user.nil? && current_user.id == user_id_was
           { users: (need.office.users.social_workers | [need.user]),
-            message: "A Volunteer has unassigned themself from the #{shift_duration_in_words} shift #{starting_day}." }
+            message: "#{current_user.first_name} #{current_user.last_name} has unassigned themself from the #{shift_duration_in_words} shift #{starting_day}." }
         elsif current_user.scheduler? && user
           { users: [user],
             message: "You have been assigned a shift #{starting_day} from #{shift_duration_in_words}." }

--- a/app/lib/services/shift_notifications/update.rb
+++ b/app/lib/services/shift_notifications/update.rb
@@ -18,7 +18,6 @@ module Services
       def call
         send_confirmation if current_user == user && user
         notification_hash[:users].each do |notified_user|
-          puts notification_hash[:message]
           SendTextMessageWorker.perform_async(notified_user.phone, [notification_hash[:message], need_url(need)].join(' '))
         end
       end


### PR DESCRIPTION
Related to [#188](https://github.com/OfficeMomsandDads/scheduler/issues/188)
### Updates
- When a volunteer claims shift social workers are sent a text with full name of volunteer.
- When a volunteer releases themselves from a shift social workers are sent text with full name of the volunteer.