### PR TITLE
Fix blockout end_at validation bug

### DIFF
--- a/app/models/blockout.rb
+++ b/app/models/blockout.rb
@@ -14,7 +14,7 @@ class Blockout < ApplicationRecord
 
   validates :end_at,
             inclusion: { in: ->(blockout) { (blockout.start_at..) }, message: 'must be beyond start at' },
-            if: :end_at_changed?,
+            if: -> { end_at_changed? || start_at_changed? },
             unless: -> { start_at.nil? }
 
   validates :last_occurrence, presence: true, if: :rrule?


### PR DESCRIPTION
The validation would not be run in the event that the start_at was advanced
beyond the end_at.