### PR TITLE
Better email validation

### DIFF
--- a/config/initializers/devise.rb
+++ b/config/initializers/devise.rb
@@ -216,7 +216,7 @@ Devise.setup do |config|
   # Email regex used to validate email formats. It simply asserts that
   # one (and only one) @ exists in the given string. This is mainly
   # to give user feedback and not to assert the e-mail validity.
-  config.email_regexp = /\A[^@\s]+@[^@\s]+\z/
+  config.email_regexp = /\A([\w+\-].?)+@[a-z\d\-\.]+(\.[a-z]+)*\.[a-z]+\z/i
 
   # ==> Configuration for :timeoutable
   # The time you want to timeout the user session without activity. After this

--- a/config/initializers/devise.rb
+++ b/config/initializers/devise.rb
@@ -213,9 +213,7 @@ Devise.setup do |config|
   # Range for password length.
   config.password_length = 6..128
 
-  # Email regex used to validate email formats. It simply asserts that
-  # one (and only one) @ exists in the given string. This is mainly
-  # to give user feedback and not to assert the e-mail validity.
+  # Email regex used to validate email formats.
   config.email_regexp = /\A([\w+\-].?)+@[a-z\d\-\.]+(\.[a-z]+)*\.[a-z]+\z/i
 
   # ==> Configuration for :timeoutable


### PR DESCRIPTION
The old regex would allow an address like the following through:

`<teresa.huber>, <.sup@dhw.idaho.gov>`

I noticed an SMTP error in production when a user entered that address.

The new regex is one we've used on another project with good success.