### PR TITLE
Block Web Requests in Test Env

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -20,7 +20,7 @@ jobs:
           POSTGRES_DB: test_db
           POSTGRES_PASSWORD: ""
       - image: circleci/redis:3.2-alpine
-      - image: selenium/standalone-chrome
+      - image: selenium/standalone-chrome:3.141.59-oxygen
     steps:
       - checkout
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -26,7 +26,7 @@ services:
       - SEED_ADMIN_PASSWORD=${SEED_ADMIN_PASSWORD}
       - SELENIUM_REMOTE_HOST=selenium
   selenium:
-    image: selenium/standalone-chrome
+    image: selenium/standalone-chrome:3.141.59-oxygen
   webpacker:
     build:
       context: ./docker/ruby

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -17,12 +17,17 @@ require 'pundit/matchers'
 require 'sidekiq/testing'
 
 include WebMock::API
+WebMock.enable!
 
 VCR.configure do |config|
-  config.allow_http_connections_when_no_cassette = true
+  config.allow_http_connections_when_no_cassette = false
   config.cassette_library_dir = 'spec/fixtures/vcr_cassettes'
   config.hook_into :webmock
   config.configure_rspec_metadata!
+  config.ignore_request do |request|
+    whitelisted_hosts = ['localhost', 'selenium', Capybara.server_host]
+    whitelisted_hosts.any? { |host| URI(request.uri).host.match?(host)  }
+  end
 end
 
 # Globally stub smartystreets


### PR DESCRIPTION
Fix a regression introduced when we implemented the system spec. This brings back the previous behavior while allowing system specs to run as expected.

Also, shamelessly stolen from @benjaminwood 