### PR TITLE
Upgrade rspec-rails to 4.0.0.beta3

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -75,7 +75,7 @@ group :development, :test do
   gem 'faker'
   gem 'pry-rails'
   gem 'pry-byebug'
-  gem 'rspec-rails'
+  gem 'rspec-rails', '>= 4.0.0.beta3'
   gem 'rspec-collection_matchers'
   gem 'shoulda-matchers'
   gem 'pundit-matchers'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -304,24 +304,24 @@ GEM
       activesupport (>= 4.1)
     rspec-collection_matchers (1.1.3)
       rspec-expectations (>= 2.99.0.beta1)
-    rspec-core (3.8.0)
-      rspec-support (~> 3.8.0)
-    rspec-expectations (3.8.2)
+    rspec-core (3.9.0)
+      rspec-support (~> 3.9.0)
+    rspec-expectations (3.9.0)
       diff-lcs (>= 1.2.0, < 2.0)
-      rspec-support (~> 3.8.0)
+      rspec-support (~> 3.9.0)
     rspec-jumpstart (1.1.2)
-    rspec-mocks (3.8.0)
+    rspec-mocks (3.9.0)
       diff-lcs (>= 1.2.0, < 2.0)
-      rspec-support (~> 3.8.0)
-    rspec-rails (3.8.1)
-      actionpack (>= 3.0)
-      activesupport (>= 3.0)
-      railties (>= 3.0)
-      rspec-core (~> 3.8.0)
-      rspec-expectations (~> 3.8.0)
-      rspec-mocks (~> 3.8.0)
-      rspec-support (~> 3.8.0)
-    rspec-support (3.8.0)
+      rspec-support (~> 3.9.0)
+    rspec-rails (4.0.0.beta3)
+      actionpack (>= 4.2)
+      activesupport (>= 4.2)
+      railties (>= 4.2)
+      rspec-core (~> 3.8)
+      rspec-expectations (~> 3.8)
+      rspec-mocks (~> 3.8)
+      rspec-support (~> 3.8)
+    rspec-support (3.9.0)
     rspec_junit_formatter (0.4.1)
       rspec-core (>= 2, < 4, != 2.12.0)
     rubocop (0.72.0)
@@ -468,7 +468,7 @@ DEPENDENCIES
   rrule
   rspec-collection_matchers
   rspec-jumpstart
-  rspec-rails
+  rspec-rails (>= 4.0.0.beta3)
   rspec_junit_formatter
   selenium-webdriver
   shoulda-matchers


### PR DESCRIPTION
The old version caused a lot of deprecation warnings and a few errors
related to the deprecation of "formats".

More info: https://github.com/rails/rails/issues/35417