### PR TITLE
Run yarn add core-js@2

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
     "@fortawesome/free-solid-svg-icons": "^5.6.3",
     "@rails/webpacker": "4.0.7",
     "babel-plugin-module-resolver": "^3.1.2",
+    "core-js": "2",
     "eslint": "^5.12.0",
     "eslint-config-hint": "^0.0.3",
     "foundation-sites": "6.5.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2561,6 +2561,11 @@ core-js-compat@^3.1.1:
     browserslist "^4.7.2"
     semver "^6.3.0"
 
+core-js@2:
+  version "2.6.10"
+  resolved "https://registry.yarnpkg.com/core-js/-/core-js-2.6.10.tgz#8a5b8391f8cc7013da703411ce5b585706300d7f"
+  integrity sha512-I39t74+4t+zau64EN1fE5v2W31Adtc/REhzWN+gWRRXg6WH5qAsZm62DHpQ1+Yhe4047T55jvzz7MUqF/dBBlA==
+
 core-js@^2.4.0, core-js@^2.5.0:
   version "2.5.7"
   resolved "https://registry.yarnpkg.com/core-js/-/core-js-2.5.7.tgz#f972608ff0cead68b841a16a932d0b183791814e"


### PR DESCRIPTION
It displays a warning message if you don't manually specify a core-js
version. I tried core-js@3 (the newer alternative) but got some errors.