### PR TITLE
Install postcss-cssnext without "--dev"

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
     "lodash": "^4.17.4",
     "moment-range": "^4.0.1",
     "moment-timezone": "^0.5.23",
+    "postcss-cssnext": "^3.1.0",
     "prop-types": "^15.6.2",
     "rails-ujs": "^5.1.4",
     "ramda": "^0.26.1",
@@ -40,7 +41,6 @@
     "babel-eslint": "^10.0.1",
     "babel-jest": "^23.4.2",
     "jest": "^23.6.0",
-    "postcss-cssnext": "^3.1.0",
     "postcss-import": "^12.0.1",
     "webpack-dev-server": "3.9.0"
   }

--- a/yarn.lock
+++ b/yarn.lock
@@ -3206,10 +3206,15 @@ ee-first@1.1.1:
   resolved "https://registry.yarnpkg.com/ee-first/-/ee-first-1.1.1.tgz#590c61156b0ae2f4f0255732a158b266bc56b21d"
   integrity sha1-WQxhFWsK4vTwJVcyoViyZrxWsh0=
 
-electron-to-chromium@^1.3.295, electron-to-chromium@^1.3.30:
+electron-to-chromium@^1.3.295:
   version "1.3.304"
   resolved "https://registry.yarnpkg.com/electron-to-chromium/-/electron-to-chromium-1.3.304.tgz#49b47d961f8143116174c2f70fbfee3aabf43015"
   integrity sha512-a5mqa13jCdBc+Crgk3Gyr7vpXCiFWfFq23YDCEmrPYeiDOQKZDVE6EX/Q4Xdv97n3XkcjiSBDOY0IS19yP2yeA==
+
+electron-to-chromium@^1.3.30:
+  version "1.3.305"
+  resolved "https://registry.yarnpkg.com/electron-to-chromium/-/electron-to-chromium-1.3.305.tgz#64f38c2986277b15c7b2c81954171ed22bee249b"
+  integrity sha512-jBEhRZ3eeJWf3eAnGYB1vDy09uBQpZWshC5fxiiIRofA9L3vkpa3SxsXleVS2MvuYir15oTVxzWPsOwj7KBzUw==
 
 elliptic@^6.0.0:
   version "6.4.1"


### PR DESCRIPTION
I previously installed the postcss-cssnext JS package with the "--dev"
flag, because that's how someone said to do it in a Github post. However
I now think it's responsible for the failures on staging and was able to
reproduce it locally. I uninstalled the --dev version and just installed
it normally and now it seems to work.