### PR TITLE
Specify corejs version in .babelrc

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -8,7 +8,8 @@
           "browsers": "> 1%",
         },
         "forceAllTransforms": true,
-        "useBuiltIns": "entry"
+        "useBuiltIns": "entry",
+        "corejs": "2"
       }
     ],
     "@babel/preset-react"


### PR DESCRIPTION
Gets rid of a deprecation warning. I thought installing core-js fixed
it, but it needs to be specified here as well.