### PR TITLE
Replace uglify key with forceAllTransforms

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -6,8 +6,8 @@
         "modules": false,
         "targets": {
           "browsers": "> 1%",
-          "uglify": true
         },
+        "forceAllTransforms": true,
         "useBuiltIns": "entry"
       }
     ],


### PR DESCRIPTION
Gets rid of a warning that the uglify key was deprecated and needs to be
replaced with this. Note that does does not go in "targets" but rather
the root level of the preset configuration.

See https://github.com/babel/babel/issues/8164