### PR TITLE
Unlock gems with no new versions

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -6,9 +6,9 @@ ruby '2.6.5'
 # Bundle edge Rails instead: gem 'rails', github: 'rails/rails'
 gem 'rails', '~> 6.0.0'
 # Use postgresql as the database for Active Record
-gem 'pg', '>= 0.18', '< 2.0'
+gem 'pg'
 # Use Puma as the app server
-gem 'puma'
+gem 'puma', '< 4.3'
 # Transpile app-like JavaScript. Read more: https://github.com/rails/webpacker
 gem 'webpacker'
 gem 'react-rails'
@@ -16,9 +16,9 @@ gem 'react-rails'
 # gem 'mini_racer', platforms: :ruby
 
 # Turbolinks makes navigating your web application faster. Read more: https://github.com/turbolinks/turbolinks
-gem 'turbolinks', '~> 5'
+gem 'turbolinks'
 # Build JSON APIs with ease. Read more: https://github.com/rails/jbuilder
-gem 'jbuilder', '~> 2.5'
+gem 'jbuilder'
 # Use Redis adapter to run Action Cable in production
 gem 'redis'
 # Use ActiveModel has_secure_password
@@ -31,7 +31,7 @@ gem 'redis'
 # gem 'capistrano-rails', group: :development
 
 # Reduces boot times through caching; required in config/boot.rb
-gem 'bootsnap', '>= 1.1.0', require: false
+gem 'bootsnap', require: false
 
 # Lib for building admin
 gem 'administrate'
@@ -62,7 +62,7 @@ gem 'sidekiq'
 gem 'twilio-ruby'
 
 # Exception monitoring
-gem 'honeybadger', '~> 4.0'
+gem 'honeybadger'
 
 # For phone number validation/formatting
 gem 'telephone_number'
@@ -92,16 +92,16 @@ gem 'simplecov', :require => false, :group => :test
 
 group :development do
   # Access an interactive console on exception pages or by calling 'console' anywhere in the code.
-  gem 'web-console', '>= 3.3.0'
+  gem 'web-console'
   gem 'listen', '>= 3.0.5', '< 3.2'
   # Spring speeds up development by keeping your application running in the background. Read more: https://github.com/rails/spring
   gem 'spring'
-  gem 'spring-watcher-listen', '~> 2.0.0'
-  gem 'hint-rubocop_style', '~> 0.3.2'
+  gem 'spring-watcher-listen'
+  gem 'hint-rubocop_style'
 end
 
 group :test do
-  gem 'capybara', '>= 2.15'
+  gem 'capybara'
   gem 'mutant',  github: 'mbj/mutant', ref: '90d103dc323eded68a7e80439def069f18b5e990'
   gem 'mutant-rspec',  github: 'mbj/mutant', ref: '90d103dc323eded68a7e80439def069f18b5e990'
   gem 'selenium-webdriver'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -448,9 +448,9 @@ DEPENDENCIES
   adamantium
   administrate
   awesome_print
-  bootsnap (>= 1.1.0)
+  bootsnap
   byebug
-  capybara (>= 2.15)
+  capybara
   concord
   devise
   devise_invitable
@@ -459,18 +459,18 @@ DEPENDENCIES
   faker
   geocoder
   haml-rails
-  hint-rubocop_style (~> 0.3.2)
-  honeybadger (~> 4.0)
-  jbuilder (~> 2.5)
+  hint-rubocop_style
+  honeybadger
+  jbuilder
   listen (>= 3.0.5, < 3.2)
   mainstreet
   mutant!
   mutant-rspec!
-  pg (>= 0.18, < 2.0)
+  pg
   procto
   pry-byebug
   pry-rails
-  puma
+  puma (< 4.3)
   pundit
   pundit-matchers
   rails (~> 6.0.0)
@@ -489,13 +489,13 @@ DEPENDENCIES
   simplecov
   spring
   spring-commands-rspec
-  spring-watcher-listen (~> 2.0.0)
+  spring-watcher-listen
   telephone_number
-  turbolinks (~> 5)
+  turbolinks
   twilio-ruby
   tzinfo-data
   vcr
-  web-console (>= 3.3.0)
+  web-console
   webmock
   webpacker
 


### PR DESCRIPTION
There's not much justification to keep them locked without a breaking
new version.
Also, lock puma to '< 4.3' temporarily, just because they released a new
version just now; will update that in a subsequent PR.