### PR TITLE
Remove tzinfo-data

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -106,7 +106,3 @@ group :test do
   gem 'mutant-rspec',  github: 'mbj/mutant', ref: '90d103dc323eded68a7e80439def069f18b5e990'
   gem 'selenium-webdriver'
 end
-
-
-# Windows does not include zoneinfo files, so bundle the tzinfo-data gem
-gem 'tzinfo-data', platforms: [:mingw, :mswin, :x64_mingw, :jruby]

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -493,7 +493,6 @@ DEPENDENCIES
   telephone_number
   turbolinks (~> 5)
   twilio-ruby
-  tzinfo-data
   vcr
   web-console (>= 3.3.0)
   webmock


### PR DESCRIPTION
It writes a message every time we run bundle, and it doesn't really
provide any real utility, even when developing on Windows.