### PR TITLE
Set extract_css to true on all environments

### DIFF
--- a/config/webpacker.yml
+++ b/config/webpacker.yml
@@ -17,7 +17,7 @@ default: &default
   cache_manifest: false
 
   # Extract and emit a css file
-  extract_css: false
+  extract_css: true
 
   static_assets_extensions:
     - .jpg


### PR DESCRIPTION
This was causing at least one display error. It's a bit confusing to me
why they opted to make this false by default.

The same exact option is set to true in the production environment. I
opted not to remove this line, even though it's redundant, to keep as
close as possible to the webpacker defaults.

See https://github.com/rails/webpacker/pull/1625