### PR TITLE
Fix blockouts notification recipients specs

### DIFF
--- a/spec/lib/services/notifications/needs/recipients/create_spec.rb
+++ b/spec/lib/services/notifications/needs/recipients/create_spec.rb
@@ -43,7 +43,9 @@ RSpec.describe Services::Notifications::Needs::Recipients::Create do
       let(:blockout) do
         build(:blockout, start_at: need.start_at, end_at: need.end_at)
       end
-      let(:unavailable_user) { build(:user, blockouts: [blockout]) }
+      let(:unavailable_user) {
+        build(:user, age_ranges: need.age_ranges, blockouts: [blockout])
+      }
 
       it 'excludes the unavailable volunteers' do
         need.office.users << [volunteer, unavailable_user]

--- a/spec/lib/services/notifications/needs/recipients/update_spec.rb
+++ b/spec/lib/services/notifications/needs/recipients/update_spec.rb
@@ -38,7 +38,9 @@ RSpec.describe Services::Notifications::Needs::Recipients::Update do
       let(:blockout) do
         build(:blockout, start_at: need.start_at, end_at: need.end_at)
       end
-      let(:unavailable_user) { build(:user, blockouts: [blockout]) }
+      let(:unavailable_user) {
+        build(:user, age_ranges: need.age_ranges, blockouts: [blockout])
+      }
 
       before { need.office.users << [user, unavailable_user] }
 

--- a/spec/lib/services/notifications/shifts/recipients/create_spec.rb
+++ b/spec/lib/services/notifications/shifts/recipients/create_spec.rb
@@ -37,7 +37,9 @@ RSpec.describe Services::Notifications::Shifts::Recipients::Create do
       let(:blockout) do
         create(:blockout, start_at: shift.start_at, end_at: shift.end_at)
       end
-      let(:unavailable_user) { create(:user, blockouts: [blockout]) }
+      let(:unavailable_user) {
+        create(:user, age_ranges: need.age_ranges, blockouts: [blockout])
+      }
 
       before { shift.need.office.users << [user, unavailable_user] }
 


### PR DESCRIPTION
While these specs passed before, they were passing even if no blockout was
assigned, due to the age ranges not being specified on the volunteer.