### PR TITLE
Set autoloader to :classic in environments/test.rb

### DIFF
--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -7,6 +7,7 @@ Rails.application.configure do
   # Settings specified here will take precedence over those in config/application.rb.
 
   config.cache_classes = true
+  config.autoloader = :classic # helps with spring and rails 6
 
   # Do not eager load code on boot. This avoids loading your whole application
   # just for the purpose of running a single test. If you are using a tool that


### PR DESCRIPTION
Rails 6's new autoloader, zeitwerk, seems to cause some problems with
using Spring for tests. If you modify a file and re-run a spec, it'll
give the error "reloading is disabled because config.cache_classes is
true". It'll work again on the second re-run, but is inconvenient.

There's an issue on Github about it here:
https://github.com/rails/spring/issues/598. They seem to have concluded
it's a bug and the best workaround is to switch back to the classic
autoloader for now.