### PR TITLE
Set cache_classes to false in test.rb

### DIFF
--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -6,7 +6,7 @@
 Rails.application.configure do
   # Settings specified here will take precedence over those in config/application.rb.
 
-  config.cache_classes = true
+  config.cache_classes = false
 
   # Do not eager load code on boot. This avoids loading your whole application
   # just for the purpose of running a single test. If you are using a tool that


### PR DESCRIPTION
This is the Rails default and solves an issue related to zeitwerk
autoloading with Spring.

Resolves issue in this PR https://github.com/OfficeMomsandDads/scheduler/pull/323