### PR TITLE
Refactor notified_user_ids

### DIFF
--- a/app/controllers/needs_controller.rb
+++ b/app/controllers/needs_controller.rb
@@ -50,8 +50,7 @@ class NeedsController < ApplicationController
     authorize @need
 
     if @need.save
-      notify_users_of_update
-
+      Services::Notifications::Needs.new(@need, :update).notify
       redirect_to(@need)
     else
       render(:edit)
@@ -80,12 +79,4 @@ class NeedsController < ApplicationController
 
     params[:need][:expected_duration] = (params[:need][:expected_duration].to_f * 60).to_s
   end
-
-  def notify_users_of_update
-    Services::Notifications::Needs.new(@need, :update).notify do |notifier|
-      @need.notified_user_ids |= notifier.recipients.map(&:id)
-      @need.save!
-    end
-  end
-
 end

--- a/app/lib/services/notifications/needs.rb
+++ b/app/lib/services/notifications/needs.rb
@@ -14,7 +14,8 @@ module Services
       def notify
         Services::TextMessageEnqueue.send_messages(phone_numbers, message)
         unless need.destroyed?
-          need.update! notified_user_ids: recipients.map(&:id)
+          need.notified_user_ids |= recipients.map(&:id)
+          need.save!
         end
 
         yield(self) if block_given?

--- a/app/lib/services/notifications/needs.rb
+++ b/app/lib/services/notifications/needs.rb
@@ -3,15 +3,19 @@
 module Services
   module Notifications
     class Needs
-      attr_accessor :message, :recipients
+      attr_accessor :message, :recipients, :need
 
       def initialize(need, action, _event_data = {})
         self.message    = Message.new(need, action).message
         self.recipients = Recipients.new(need, action).recipients
+        self.need = need
       end
 
       def notify
         Services::TextMessageEnqueue.send_messages(phone_numbers, message)
+        unless need.destroyed?
+          need.update! notified_user_ids: recipients.map(&:id)
+        end
 
         yield(self) if block_given?
       end

--- a/app/lib/services/notifications/shifts.rb
+++ b/app/lib/services/notifications/shifts.rb
@@ -5,16 +5,17 @@ module Services
     class Shifts
       include Adamantium::Flat
 
-      attr_accessor :message,
-                    :recipients
+      attr_accessor :message, :recipients, :shift
 
       def initialize(shift, action, event_data = {})
         self.message    = Message.new(shift, action, event_data).message
         self.recipients = Recipients.new(shift, action, event_data).recipients
+        self.shift = shift
       end
 
       def notify
         Services::TextMessageEnqueue.send_messages(phone_numbers, message)
+        shift.need.update! notified_user_ids: recipients.map(&:id)
 
         yield(self) if block_given?
       end

--- a/app/lib/services/notifications/shifts.rb
+++ b/app/lib/services/notifications/shifts.rb
@@ -15,7 +15,8 @@ module Services
 
       def notify
         Services::TextMessageEnqueue.send_messages(phone_numbers, message)
-        shift.need.update! notified_user_ids: recipients.map(&:id)
+        shift.need.notified_user_ids |= recipients.map(&:id)
+        shift.need.save!
 
         yield(self) if block_given?
       end

--- a/app/models/need.rb
+++ b/app/models/need.rb
@@ -50,9 +50,7 @@ class Need < ApplicationRecord
   end
 
   def notification_candidates
-    office
-      .notifiable_users
-      .where.not(id: notified_user_ids | [user_id])
+    office.notifiable_users
   end
 
   def users_to_notify

--- a/spec/lib/services/notifications/needs/recipients/create_spec.rb
+++ b/spec/lib/services/notifications/needs/recipients/create_spec.rb
@@ -57,13 +57,13 @@ RSpec.describe Services::Notifications::Needs::Recipients::Create do
     end
 
     context 'with users already notified' do
-      it 'does not notify users again' do
+      it 'notifies users again' do
         need.office.users << volunteer
         need.update(notified_user_ids: [volunteer.id])
 
         result = subject
 
-        expect(result).to be_empty
+        expect(result).to include(volunteer)
       end
     end
 

--- a/spec/lib/services/notifications/needs/recipients/update_spec.rb
+++ b/spec/lib/services/notifications/needs/recipients/update_spec.rb
@@ -50,11 +50,13 @@ RSpec.describe Services::Notifications::Needs::Recipients::Update do
     end
 
     context 'with users already notified' do
-      it 'does not notify users again' do
+      let(:user) { create(:user, age_ranges: need.age_ranges) }
+
+      it 'notifies users again' do
         need.office.users << user
         need.update(notified_user_ids: [user.id])
 
-        expect(subject).not_to include(user)
+        expect(subject).to include(user)
       end
     end
 

--- a/spec/lib/services/notifications/needs_spec.rb
+++ b/spec/lib/services/notifications/needs_spec.rb
@@ -12,7 +12,7 @@ RSpec.describe Services::Notifications::Needs do
   let(:shift) { need.shifts.first! }
   let(:phone) { '(360) 555-0110' }
   let!(:shift_user) do
-    u          = create(:user, phone: phone)
+    u          = create(:user, phone: phone, age_ranges: need.age_ranges)
     shift.user = u
     shift.save!
     u
@@ -34,6 +34,25 @@ RSpec.describe Services::Notifications::Needs do
       expect do
         object.notify { puts 'hello' }
       end.to output("hello\n").to_stdout
+    end
+
+    describe 'notified_user_ids' do
+      let(:action) { :update }
+
+      it 'adds to notified_user_ids' do
+        expect(need.notified_user_ids).to be_empty
+        need.office.users << shift_user
+        expect(need.users_to_notify).to eq([shift_user])
+        object.notify
+        expect(need.notified_user_ids).to eq([shift_user.id])
+      end
+
+      it 'does not remove from notified_user_ids' do
+        need.update notified_user_ids: [shift_user.id]
+        expect(need.users_to_notify).to be_empty
+        object.notify
+        expect(need.notified_user_ids).to eq([shift_user.id])
+      end
     end
   end
 

--- a/spec/lib/services/notifications/shifts/recipients/create_spec.rb
+++ b/spec/lib/services/notifications/shifts/recipients/create_spec.rb
@@ -49,11 +49,13 @@ RSpec.describe Services::Notifications::Shifts::Recipients::Create do
     end
 
     context 'with users already notified' do
-      it 'does not notify users again' do
+      let(:user) { create(:user, age_ranges: need.age_ranges) }
+
+      it 'notifies users again' do
         shift.need.office.users << user
         shift.need.update(notified_user_ids: [user.id])
 
-        expect(object.recipients).not_to include(user)
+        expect(object.recipients).to include(user)
       end
     end
 

--- a/spec/lib/services/notifications/shifts_spec.rb
+++ b/spec/lib/services/notifications/shifts_spec.rb
@@ -17,7 +17,7 @@ RSpec.describe Services::Notifications::Shifts do
   let(:shift) { need.shifts.first! }
   let(:phone) { '(360) 555-0110' }
   let!(:shift_user) do
-    u          = create(:user, phone: phone)
+    u          = create(:user, phone: phone, age_ranges: need.age_ranges)
     shift.user = u
     shift.save!
     u
@@ -44,6 +44,23 @@ RSpec.describe Services::Notifications::Shifts do
       expect do
         object.notify { puts 'hello' }
       end.to output("hello\n").to_stdout
+    end
+
+    describe 'notified_user_ids' do
+      it 'adds to notified_user_ids' do
+        expect(need.notified_user_ids).to be_empty
+        need.office.users << shift_user
+        expect(need.users_to_notify).to eq([shift_user])
+        object.notify
+        expect(need.notified_user_ids).to eq([shift_user.id])
+      end
+
+      it 'does not remove from notified_user_ids' do
+        need.update notified_user_ids: [shift_user.id]
+        expect(need.users_to_notify).to be_empty
+        object.notify
+        expect(need.notified_user_ids).to eq([shift_user.id])
+      end
     end
   end
 


### PR DESCRIPTION
The old behavior was inconsistent and was probably causing users not to
receive desired notifications. For one thing, it only set
notified_user_ids when a need was updated; not when a need was created,
or a shift was created or updated. Second, it would exclude all future
notifications to the user once it was set, even if they would expect
them, such as needs or shifts being updated.

This commit changes that. Now, it will overwrite notified_user_ids
whenever a notification goes out related to the needs or shifts. It also
will not use notified_user_ids to exclude people from notifications.

This means that notified_user_ids is currently not being used at all
aside for as a field that is set when notifications go out. However, I
intend to use it in the future for the "users pending response" feature.

This commit also fixes some related specs which were passing before
whether or not the condition was being met, due to improper data setup
regarding age_ranges.