### PR TITLE
Allow volunteers to mark themselves as unavailable

### DIFF
--- a/app/controllers/needs_controller.rb
+++ b/app/controllers/needs_controller.rb
@@ -72,6 +72,14 @@ class NeedsController < ApplicationController
     end
   end
 
+  def mark_unavailable
+    @need = policy_scope(Need).find(params[:id])
+    authorize @need
+    @need.unavailable_user_ids << current_user.id
+    @need.save
+    redirect_to @need
+  end
+
   private
 
   def convert_to_minutes!

--- a/app/javascript/packs/application.js
+++ b/app/javascript/packs/application.js
@@ -11,6 +11,7 @@ import OMDLogo from 'images/omd-logo-horiz.png'
 import moment from 'moment-timezone'
 import { extendMoment } from 'moment-range'
 import 'react-toggle/style.css'
+import '../src/responses'
 
 moment.tz.setDefault(window.timeZone)
 window.moment = extendMoment(moment)

--- a/app/javascript/src/responses.js
+++ b/app/javascript/src/responses.js
@@ -1,0 +1,11 @@
+$(document).ready(function() {
+  $('#toggle-unavailable-list').on('click', function(e) {
+    e.preventDefault();
+    $('#unavailable-list').toggleClass('hide');
+  });
+
+  $('#toggle-pending-list').on('click', function(e) {
+    e.preventDefault();
+    $('#pending-list').toggleClass('hide');
+  });
+});

--- a/app/models/need.rb
+++ b/app/models/need.rb
@@ -50,7 +50,9 @@ class Need < ApplicationRecord
   end
 
   def notification_candidates
-    office.notifiable_users
+    office
+      .notifiable_users
+      .where.not(id: unavailable_user_ids | [user_id])
   end
 
   def users_to_notify
@@ -58,5 +60,13 @@ class Need < ApplicationRecord
       .exclude_blockouts(start_at, end_at)
       .then { |users| scope_users_by_language(users) }
       .then { |users| scope_users_by_age_ranges(users) }
+  end
+
+  def unavailable_users
+    User.find(unavailable_user_ids)
+  end
+
+  def users_pending_response
+    User.find(notified_user_ids - unavailable_user_ids - shifts.map(&:user_id))
   end
 end

--- a/app/models/need.rb
+++ b/app/models/need.rb
@@ -67,6 +67,6 @@ class Need < ApplicationRecord
   end
 
   def users_pending_response
-    User.find(notified_user_ids - unavailable_user_ids - shifts.map(&:user_id))
+    User.find(notified_user_ids - unavailable_user_ids - shifts.pluck(:user_id))
   end
 end

--- a/app/models/need.rb
+++ b/app/models/need.rb
@@ -55,7 +55,7 @@ class Need < ApplicationRecord
 
   def users_to_notify
     notification_candidates
-      .available_within(start_at, end_at)
+      .exclude_blockouts(start_at, end_at)
       .then { |users| scope_users_by_language(users) }
       .then { |users| scope_users_by_age_ranges(users) }
   end

--- a/app/models/shift.rb
+++ b/app/models/shift.rb
@@ -9,6 +9,7 @@ class Shift < ApplicationRecord
   belongs_to :user, optional: true
   before_destroy :notify_user_of_cancelation,
                  if: -> { user&.phone.present? }
+  after_create :clear_unavailable_users
 
   validates :duration,
             :start_at,
@@ -56,5 +57,11 @@ class Shift < ApplicationRecord
     return true if need.shifts.many?
 
     errors.add(:need, :remove_last_shift) && false
+  end
+
+  private
+
+  def clear_unavailable_users
+    need.update unavailable_user_ids: []
   end
 end

--- a/app/models/shift.rb
+++ b/app/models/shift.rb
@@ -47,7 +47,7 @@ class Shift < ApplicationRecord
   def users_to_notify
     # this differs from Need#users_to_notify because start_at and end_at differ
     notification_candidates
-      .available_within(start_at, end_at)
+      .exclude_blockouts(start_at, end_at)
       .then { |users| scope_users_by_language(users) }
       .then { |users| scope_users_by_age_ranges(users) }
   end

--- a/app/models/shift.rb
+++ b/app/models/shift.rb
@@ -10,6 +10,7 @@ class Shift < ApplicationRecord
   before_destroy :notify_user_of_cancelation,
                  if: -> { user&.phone.present? }
   after_create :clear_unavailable_users
+  after_update :make_user_available
 
   validates :duration,
             :start_at,
@@ -62,6 +63,13 @@ class Shift < ApplicationRecord
   private
 
   def clear_unavailable_users
-    need.update unavailable_user_ids: []
+    need.update! unavailable_user_ids: []
+  end
+
+  def make_user_available
+    if need.unavailable_user_ids.include?(user_id)
+      need.unavailable_user_ids -= [user_id]
+      need.save!
+    end
   end
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -120,7 +120,7 @@ class User < ApplicationRecord
     shifts_by_user.sum('shifts.duration')
   end
 
-  def self.available_within(start_at, end_at)
+  def self.exclude_blockouts(start_at, end_at)
     sql = <<~SQL
       LEFT OUTER JOIN blockouts
       ON blockouts.user_id = users.id

--- a/app/policies/need_policy.rb
+++ b/app/policies/need_policy.rb
@@ -29,6 +29,14 @@ class NeedPolicy < ApplicationPolicy
     create?
   end
 
+  def mark_unavailable?
+    show?
+  end
+
+  def view_responses?
+    create?
+  end
+
   def permitted_attributes_for_create
     permitted_attributes | %i(office_id start_at expected_duration)
   end

--- a/app/views/needs/show.html.haml
+++ b/app/views/needs/show.html.haml
@@ -79,26 +79,27 @@
               .cell
                 %i.fas.fa-calendar-plus
                 Claim Shift
-%h2 Response
-.unavailable-container
-  - if @need.notified_user_ids.include?(current_user.id)
-    - if @need.unavailable_user_ids.include?(current_user.id)
-      %p You have marked yourself as unavailable for this need.
-    - else
-      = form_tag mark_unavailable_need_path(@need), method: :patch do
-        = submit_tag 'I am not available for this request.', class: 'button alert'
-      %br
-- if policy(@need).view_responses?
-  .responses-container
-    %p
-      = link_to pluralize(@need.unavailable_users.size, 'volunteer'), '#', id: 'toggle-unavailable-list'
-      cannot fill this request
-    %ul#unavailable-list.hide
-      - @need.unavailable_users.each do |user|
-        %li= user.name
-    %p
-      = link_to pluralize(@need.users_pending_response.size, 'volunteer'), '#', id: 'toggle-pending-list'
-      have not yet responded
-    %ul#pending-list.hide
-      - @need.users_pending_response.each do |user|
-        %li= user.name
+- if @need.notified_user_ids.present?
+  %h2 Response
+  .unavailable-container
+    - if @need.notified_user_ids.include?(current_user.id)
+      - if @need.unavailable_user_ids.include?(current_user.id)
+        %p You have marked yourself as unavailable for this need.
+      - else
+        = form_tag mark_unavailable_need_path(@need), method: :patch do
+          = submit_tag 'I am not available for this request.', class: 'button alert'
+        %br
+  - if policy(@need).view_responses?
+    .responses-container
+      %p
+        = link_to pluralize(@need.unavailable_users.size, 'volunteer'), '#', id: 'toggle-unavailable-list'
+        cannot fill this request
+      %ul#unavailable-list.hide
+        - @need.unavailable_users.each do |user|
+          %li= user.name
+      %p
+        = link_to pluralize(@need.users_pending_response.size, 'volunteer'), '#', id: 'toggle-pending-list'
+        have not yet responded
+      %ul#pending-list.hide
+        - @need.users_pending_response.each do |user|
+          %li= user.name

--- a/app/views/needs/show.html.haml
+++ b/app/views/needs/show.html.haml
@@ -80,11 +80,13 @@
                 %i.fas.fa-calendar-plus
                 Claim Shift
 - if @need.notified_user_ids.present?
-  %h2 Response
-  .unavailable-container
-    - if @need.notified_user_ids.include?(current_user.id)
-      - if @need.unavailable_user_ids.include?(current_user.id)
-        %p You have marked yourself as unavailable for this need.
+  - if @need.notified_user_ids.include?(current_user.id)
+    %br
+    .unavailable-container
+      - if @need.shifts.where(user_id: current_user.id).present?
+        %p You have claimed a shift.
+      - elsif @need.unavailable_user_ids.include?(current_user.id)
+        %p You have marked yourself as unavailable for this request.
       - else
         = form_tag mark_unavailable_need_path(@need), method: :patch do
           = submit_tag 'I am not available for this request.', class: 'button alert'

--- a/app/views/needs/show.html.haml
+++ b/app/views/needs/show.html.haml
@@ -54,7 +54,7 @@
         .grid-x.grid-padding-x.grid-padding-y
           .cell.text-center
             %strong= shift.start_at.strftime('%I:%M%p')
-            - if policy(@need).edit? 
+            - if policy(@need).edit?
               = " - #{shift.user&.to_s}"
       .cell.small-12.medium-3.large-2
         - if !shift.expired? && shift.user_id == current_user.id
@@ -79,4 +79,26 @@
               .cell
                 %i.fas.fa-calendar-plus
                 Claim Shift
-      
+%h2 Response
+.unavailable-container
+  - if @need.notified_user_ids.include?(current_user.id)
+    - if @need.unavailable_user_ids.include?(current_user.id)
+      %p You have marked yourself as unavailable for this need.
+    - else
+      = form_tag mark_unavailable_need_path(@need), method: :patch do
+        = submit_tag 'I am not available for this request.', class: 'button alert'
+      %br
+- if policy(@need).view_responses?
+  .responses-container
+    %p
+      = link_to pluralize(@need.unavailable_users.size, 'volunteer'), '#', id: 'toggle-unavailable-list'
+      cannot fill this request
+    %ul#unavailable-list.hide
+      - @need.unavailable_users.each do |user|
+        %li= user.name
+    %p
+      = link_to pluralize(@need.users_pending_response.size, 'volunteer'), '#', id: 'toggle-pending-list'
+      have not yet responded
+    %ul#pending-list.hide
+      - @need.users_pending_response.each do |user|
+        %li= user.name

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -34,6 +34,7 @@ Rails.application.routes.draw do
   resources :blockouts, except: %i[index new edit show]
   resources :needs do
     resources :shifts, except: %i[new]
+    patch 'mark_unavailable', on: :member
   end
 
   root to: 'needs#index'

--- a/db/migrate/20191114232842_add_unavailable_users.rb
+++ b/db/migrate/20191114232842_add_unavailable_users.rb
@@ -1,0 +1,5 @@
+class AddUnavailableUsers < ActiveRecord::Migration[6.0]
+  def change
+    add_column :needs, :unavailable_user_ids, :bigint, default: [], array: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2019_11_13_175940) do
+ActiveRecord::Schema.define(version: 2019_11_14_232842) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -81,6 +81,7 @@ ActiveRecord::Schema.define(version: 2019_11_13_175940) do
     t.datetime "updated_at", null: false
     t.bigint "race_id"
     t.text "notes"
+    t.bigint "unavailable_user_ids", default: [], array: true
     t.index ["office_id"], name: "index_needs_on_office_id"
     t.index ["preferred_language_id"], name: "index_needs_on_preferred_language_id"
     t.index ["race_id"], name: "index_needs_on_race_id"

--- a/spec/controllers/needs_controller_spec.rb
+++ b/spec/controllers/needs_controller_spec.rb
@@ -23,42 +23,10 @@ RSpec.describe NeedsController, type: :controller do
   end
 
   describe '#show' do
-    subject { get :show, params: { id: need.id } }
-
-    render_views
-
     it 'returns ok and sets expected variables' do
-      subject
+      get :show, params: { id: need.id }
       expect(response).to have_http_status(:ok)
       expect(flash[:alert]).to be nil
-    end
-
-    context 'when user has not been notified' do
-      it 'does not show unavailability button' do
-        subject
-        assert_select ".unavailable-container input[type=submit]" +
-          "[value='I am not available for this request.']", 0
-      end
-    end
-
-    context 'when user has been notified' do
-      before { need.update(notified_user_ids: [user.id]) }
-
-      it 'shows unavailability button' do
-        subject
-        assert_select ".unavailable-container input[type=submit]" +
-          "[value='I am not available for this request.']"
-      end
-
-      context 'when user has marked themselves unavailable' do
-        before { need.update(unavailable_user_ids: [user.id]) }
-
-        it 'shows user is unavailable' do
-          subject
-          assert_select '.unavailable-container p',
-            'You have marked yourself as unavailable for this need.'
-        end
-      end
     end
   end
 

--- a/spec/controllers/needs_controller_spec.rb
+++ b/spec/controllers/needs_controller_spec.rb
@@ -23,11 +23,42 @@ RSpec.describe NeedsController, type: :controller do
   end
 
   describe '#show' do
-    it 'GET show' do
-      get :show, params: { id: need.id }
+    subject { get :show, params: { id: need.id } }
 
+    render_views
+
+    it 'returns ok and sets expected variables' do
+      subject
       expect(response).to have_http_status(:ok)
       expect(flash[:alert]).to be nil
+    end
+
+    context 'when user has not been notified' do
+      it 'does not show unavailability button' do
+        subject
+        assert_select ".unavailable-container input[type=submit]" +
+          "[value='I am not available for this request.']", 0
+      end
+    end
+
+    context 'when user has been notified' do
+      before { need.update(notified_user_ids: [user.id]) }
+
+      it 'shows unavailability button' do
+        subject
+        assert_select ".unavailable-container input[type=submit]" +
+          "[value='I am not available for this request.']"
+      end
+
+      context 'when user has marked themselves unavailable' do
+        before { need.update(unavailable_user_ids: [user.id]) }
+
+        it 'shows user is unavailable' do
+          subject
+          assert_select '.unavailable-container p',
+            'You have marked yourself as unavailable for this need.'
+        end
+      end
     end
   end
 
@@ -72,4 +103,8 @@ RSpec.describe NeedsController, type: :controller do
     end
   end
 
+  describe '#mark_unavailable' do
+    subject { patch :mark_unavailable, params: { id: need.id } }
+    it { is_expected.to redirect_to(need) }
+  end
 end

--- a/spec/lib/services/notifications/needs/recipients/create_spec.rb
+++ b/spec/lib/services/notifications/needs/recipients/create_spec.rb
@@ -39,20 +39,31 @@ RSpec.describe Services::Notifications::Needs::Recipients::Create do
       end
     end
 
-    context 'with volunteers that are not available' do
+    context 'with volunteers that are blocked out' do
       let(:blockout) do
         build(:blockout, start_at: need.start_at, end_at: need.end_at)
       end
-      let(:unavailable_user) {
+      let(:blockout_user) {
         build(:user, age_ranges: need.age_ranges, blockouts: [blockout])
       }
 
-      it 'excludes the unavailable volunteers' do
-        need.office.users << [volunteer, unavailable_user]
+      it 'excludes the blocked out volunteers' do
+        need.office.users << [volunteer, blockout_user]
 
         result = subject
 
         expect(result).to eql([volunteer])
+      end
+    end
+
+    context 'with volunteers that have marked themselves unavailable' do
+      it 'excludes the unavailable volunteers' do
+        need.office.users << [volunteer]
+        need.update(unavailable_user_ids: [volunteer.id])
+
+        result = subject
+
+        expect(result).to be_empty
       end
     end
 

--- a/spec/lib/services/notifications/needs/recipients/update_spec.rb
+++ b/spec/lib/services/notifications/needs/recipients/update_spec.rb
@@ -34,18 +34,27 @@ RSpec.describe Services::Notifications::Needs::Recipients::Update do
       end
     end
 
-    context 'with volunteers that are not available' do
+    context 'with volunteers that are blocked out' do
       let(:blockout) do
         build(:blockout, start_at: need.start_at, end_at: need.end_at)
       end
-      let(:unavailable_user) {
+      let(:blockout_user) {
         build(:user, age_ranges: need.age_ranges, blockouts: [blockout])
       }
 
-      before { need.office.users << [user, unavailable_user] }
+      before { need.office.users << [user, blockout_user] }
 
       it 'excludes the unavailable volunteers' do
-        expect(subject).not_to include(unavailable_user)
+        expect(subject).not_to include(blockout_user)
+      end
+    end
+
+    context 'with volunteers that have marked themselves unavailable' do
+      it 'excludes the unavailable volunteers' do
+        need.office.users << [user]
+        need.update(unavailable_user_ids: [user.id])
+
+        expect(subject).to be_empty
       end
     end
 

--- a/spec/lib/services/notifications/shifts/recipients/create_spec.rb
+++ b/spec/lib/services/notifications/shifts/recipients/create_spec.rb
@@ -33,18 +33,27 @@ RSpec.describe Services::Notifications::Shifts::Recipients::Create do
       end
     end
 
-    context 'with volunteers that are not available' do
+    context 'with volunteers that are blocked out' do
       let(:blockout) do
         create(:blockout, start_at: shift.start_at, end_at: shift.end_at)
       end
-      let(:unavailable_user) {
+      let(:blockout_user) {
         create(:user, age_ranges: need.age_ranges, blockouts: [blockout])
       }
 
-      before { shift.need.office.users << [user, unavailable_user] }
+      before { shift.need.office.users << [user, blockout_user] }
 
+      it 'excludes the blocked out volunteers' do
+        expect(object.recipients).not_to include(blockout_user)
+      end
+    end
+
+    context 'with volunteers that have marked themselves unavailable' do
       it 'excludes the unavailable volunteers' do
-        expect(object.recipients).not_to include(unavailable_user)
+        need.office.users << [user]
+        need.update(unavailable_user_ids: [user.id])
+
+        expect(object.recipients).to be_empty
       end
     end
 

--- a/spec/models/shift_spec.rb
+++ b/spec/models/shift_spec.rb
@@ -101,4 +101,16 @@ RSpec.describe Shift, type: :model do
     end
   end
 
+  describe 'after_create :clear_unavailable_users' do
+    let(:user) { create(:user) }
+    let(:need) { shift.need }
+    before { need.update(unavailable_user_ids: [user.id]) }
+
+    it "clears the need's unavailable_user_ids on create" do
+      expect(need.unavailable_user_ids).to eq([user.id])
+      second_shift
+      expect(need.unavailable_user_ids).to be_empty
+    end
+  end
+
 end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -51,8 +51,8 @@ RSpec.describe User, type: :model do
     end
   end
 
-  describe '.available_within' do
-    subject { User.available_within(*time.values) }
+  describe '.exclude_blockouts' do
+    subject { User.exclude_blockouts(*time.values) }
 
     let(:time) { { start_at: 1.day.from_now, end_at: 1.day.from_now + 1.hour } }
 

--- a/spec/policies/need_policy_spec.rb
+++ b/spec/policies/need_policy_spec.rb
@@ -22,6 +22,8 @@ RSpec.describe NeedPolicy do
       it { is_expected.to forbid_action(:edit) }
       it { is_expected.to forbid_action(:update) }
       it { is_expected.to forbid_action(:destroy) }
+      it { is_expected.to permit_action(:mark_unavailable)}
+      it { is_expected.to forbid_action(:view_responses) }
 
       describe '.scope' do
         it 'scopes the query' do
@@ -34,6 +36,8 @@ RSpec.describe NeedPolicy do
     context 'when not of the office' do
       it { is_expected.to permit_action(:index) }
       it { is_expected.to forbid_action(:show) }
+      it { is_expected.to forbid_action(:mark_unavailable)}
+      it { is_expected.to forbid_action(:view_responses) }
 
       describe '.scope' do
         it 'scopes the query' do
@@ -56,6 +60,8 @@ RSpec.describe NeedPolicy do
     it { is_expected.to permit_action(:edit) }
     it { is_expected.to permit_action(:update) }
     it { is_expected.to permit_action(:destroy) }
+    it { is_expected.to permit_action(:mark_unavailable)}
+    it { is_expected.to permit_action(:view_responses) }
 
     describe '.scope' do
       it 'scopes the query' do
@@ -75,6 +81,8 @@ RSpec.describe NeedPolicy do
     it { is_expected.to permit_action(:edit) }
     it { is_expected.to permit_action(:update) }
     it { is_expected.to permit_action(:destroy) }
+    it { is_expected.to permit_action(:mark_unavailable) }
+    it { is_expected.to permit_action(:view_responses) }
 
     describe '.scope' do
       it 'scopes the query' do

--- a/spec/support/devise.rb
+++ b/spec/support/devise.rb
@@ -4,4 +4,5 @@ RSpec.configure do |config|
   config.include Devise::Test::ControllerHelpers, type: :controller
   config.include Devise::Test::ControllerHelpers, type: :view
   config.include Devise::Test::IntegrationHelpers, type: :request
+  config.include Devise::Test::IntegrationHelpers, type: :system
 end

--- a/spec/system/responses_spec.rb
+++ b/spec/system/responses_spec.rb
@@ -1,0 +1,32 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe 'Responses', type: :system, js: true do
+  let(:unavailable_user) { create(:user, first_name: 'Unavailable') }
+  let(:pending_user) { create(:user, first_name: 'Pending') }
+  let(:need) {
+    create(:need, notified_user_ids: [unavailable_user.id, pending_user.id])
+  }
+
+  before { sign_in need.user }
+  before { need.update unavailable_user_ids: [unavailable_user.id] }
+
+  describe 'response toggle' do
+    it 'toggle the unavailable list' do
+      visit need_path(need)
+      expect(page).not_to have_text(unavailable_user.name)
+
+      find('#toggle-unavailable-list').click()
+      expect(page).to have_text(unavailable_user.name)
+    end
+
+    it 'toggle the pending list' do
+      visit need_path(need)
+      expect(page).not_to have_text(pending_user.name)
+
+      find('#toggle-pending-list').click()
+      expect(page).to have_text(pending_user.name)
+    end
+  end
+end

--- a/spec/views/needs/show.html.haml_spec.rb
+++ b/spec/views/needs/show.html.haml_spec.rb
@@ -1,0 +1,62 @@
+require "rails_helper"
+
+RSpec.describe "needs/show", type: :view do
+  let(:need) { create(:need_with_shifts) }
+  let(:user) { create(:user) }
+
+  before {
+    assign(:need, need)
+    assign(:shifts, need.shifts.order(:start_at))
+
+    without_partial_double_verification do
+      allow(view).to receive(:policy) do |record|
+        Pundit.policy(user, record)
+      end
+      allow(view).to receive(:current_user) { user }
+    end
+  }
+
+  context 'when no users have been notified' do
+    it 'does not show Response section' do
+      render
+      expect(rendered).not_to match /Response/
+    end
+  end
+
+  context 'when users have been notified' do
+    let(:user2) { create(:user) }
+    before { need.update(notified_user_ids: [user2.id]) }
+
+    it 'does show Response section' do
+      render
+      expect(rendered).to match /Response/
+    end
+
+    context 'when current user has not been notified' do
+      it 'does not show unavailability button' do
+        render
+        expect(rendered).not_to match /I am not available for this request./
+      end
+    end
+
+    context 'when current user has been notified' do
+      before { need.update(notified_user_ids: [user.id]) }
+
+      it 'shows unavailability button' do
+        render
+        expect(rendered).to match /I am not available for this request./
+      end
+
+      context 'when current user has marked themselves unavailable' do
+        before { need.update(unavailable_user_ids: [user.id]) }
+
+        it 'shows user is unavailable' do
+          render
+          expect(rendered).to match(
+            /You have marked yourself as unavailable for this need./
+          )
+        end
+      end
+    end
+  end
+end

--- a/spec/views/needs/show.html.haml_spec.rb
+++ b/spec/views/needs/show.html.haml_spec.rb
@@ -17,9 +17,9 @@ RSpec.describe "needs/show", type: :view do
   }
 
   context 'when no users have been notified' do
-    it 'does not show Response section' do
+    it 'does not show unavailability section' do
       render
-      expect(rendered).not_to match /Response/
+      expect(rendered).not_to match /unavailable-container/
     end
   end
 
@@ -27,16 +27,9 @@ RSpec.describe "needs/show", type: :view do
     let(:user2) { create(:user) }
     before { need.update(notified_user_ids: [user2.id]) }
 
-    it 'does show Response section' do
+    it 'does not show unavailability section' do
       render
-      expect(rendered).to match /Response/
-    end
-
-    context 'when current user has not been notified' do
-      it 'does not show unavailability button' do
-        render
-        expect(rendered).not_to match /I am not available for this request./
-      end
+      expect(rendered).not_to match /unavailable-container/
     end
 
     context 'when current user has been notified' do
@@ -47,13 +40,22 @@ RSpec.describe "needs/show", type: :view do
         expect(rendered).to match /I am not available for this request./
       end
 
+      context 'when current user has accepted a shift' do
+        before { need.shifts.first.update(user: user) }
+
+        it 'does not show unavailability button' do
+          render
+          expect(rendered).to match /You have claimed a shift./
+        end
+      end
+
       context 'when current user has marked themselves unavailable' do
         before { need.update(unavailable_user_ids: [user.id]) }
 
         it 'shows user is unavailable' do
           render
           expect(rendered).to match(
-            /You have marked yourself as unavailable for this need./
+            /You have marked yourself as unavailable for this request./
           )
         end
       end


### PR DESCRIPTION
Implementation for this feature request: https://github.com/OfficeMomsandDads/scheduler/issues/212

The need show page has some new functionality. There is a "Responses" section beneath the shifts. There, notified users will be able to mark themselves as unavailable for this need. Also, admins, coordinators and social workers will be able to see who has marked themselves unavailable, as well as all notified volunteers who have not yet claimed a shift nor marked themselves unavailable.

If marked unavailable, a user will not receive any more notifications related to this need, *unless* a new shift is created. If a new shift is created, the unavailable users list is wiped clean, and users will have to mark themselves as unavailable again (or claim the new shift).

Includes some simple JS to toggle the lists of users.