### PR TITLE
Pre-verify user phone numbers

### DIFF
--- a/db/migrate/20191209221008_pre_verify_eligible_users.rb
+++ b/db/migrate/20191209221008_pre_verify_eligible_users.rb
@@ -1,16 +1,19 @@
 class PreVerifyEligibleUsers < ActiveRecord::Migration[6.0]
   def up
     User.where.not(phone: nil).find_each do |user|
-      sleep 1
-      messages = $twilio.messages.list(to: user.phone, limit: 100)
-      messages.each do |m|
-        if m.status == 'delivered'
-          user.update! verified: true
-          puts "marked user #{user.id} as verified"
-          break
+      begin
+        messages = $twilio.messages.list(to: user.phone, limit: 100)
+        messages.each do |m|
+          if m.status == 'delivered'
+            user.update! verified: true
+            puts "marked user #{user.id} as verified"
+            break
+          end
         end
+        puts "could not find delivered message for #{user.id}"
+      rescue Exception => e
+        puts "error while processing user #{user.id}: #{e}"
       end
-      puts "could not find delivered message for #{user.id}"
     end
   end
 end

--- a/db/migrate/20191209221008_pre_verify_eligible_users.rb
+++ b/db/migrate/20191209221008_pre_verify_eligible_users.rb
@@ -1,0 +1,16 @@
+class PreVerifyEligibleUsers < ActiveRecord::Migration[6.0]
+  def up
+    User.where.not(phone: nil).find_each do |user|
+      sleep 1
+      messages = $twilio.messages.list(to: user.phone, limit: 100)
+      messages.each do |m|
+        if m.status == 'delivered'
+          user.update! verified: true
+          puts "marked user #{user.id} as verified"
+          break
+        end
+      end
+      puts "could not find delivered message for #{user.id}"
+    end
+  end
+end

--- a/db/migrate/20191209221008_pre_verify_eligible_users.rb
+++ b/db/migrate/20191209221008_pre_verify_eligible_users.rb
@@ -1,5 +1,6 @@
 class PreVerifyEligibleUsers < ActiveRecord::Migration[6.0]
   def up
+    return unless Rails.env.production?
     User.where.not(phone: nil).find_each do |user|
       begin
         messages = $twilio.messages.list(to: user.phone, limit: 100)

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2019_12_09_174202) do
+ActiveRecord::Schema.define(version: 2019_12_09_221008) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"


### PR DESCRIPTION
This is our grandfather clause, which allows users currently on the platform to skip the verification process if they have already been receiving text messages successfully. While this doesn't ensure that they own the phone number which is receiving the messages, it's likely to satisfy the vast majority of cases. After this migration, all users will have to verify using the standard method.

This commit merely reverts an earlier commit, which itself reverts a commit, which contains the migration code.

Implements #200 