### PR TITLE
Make phone verification mandatory

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -46,8 +46,8 @@ class ApplicationController < ActionController::Base
   end
 
   def enforce_verification
-    if !current_user.verified? && !devise_controller?
-      redirect_to verify_path
-    end
+    return if current_user.verified? || devise_controller?
+
+    redirect_to verify_path
   end
 end

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -7,6 +7,7 @@ class ApplicationController < ActionController::Base
 
   before_action :authenticate_user!
   before_action :configure_permitted_parameters, if: :devise_controller?
+  before_action :enforce_verification, if: :user_signed_in?
   around_action :set_time_zone, if: :user_signed_in?
 
   rescue_from Pundit::NotAuthorizedError, with: :user_not_authorized
@@ -42,5 +43,11 @@ class ApplicationController < ActionController::Base
     yield
   ensure
     Time.zone = Scheduler::Application.config.time_zone
+  end
+
+  def enforce_verification
+    if !current_user.verified? && !devise_controller?
+      redirect_to verify_path
+    end
   end
 end

--- a/app/controllers/verifications_controller.rb
+++ b/app/controllers/verifications_controller.rb
@@ -9,7 +9,7 @@ class VerificationsController < ApplicationController
   def send_code
     $twilio.verify.services(VERIFY_SID).verifications.
       create(to: current_user.e164_phone, channel: 'sms')
-    redirect_to verify_path, flash: { notice: 'Verification code has been sent' }
+    redirect_to verify_path(verification_sent: true)
   end
 
   def check_code

--- a/app/controllers/verifications_controller.rb
+++ b/app/controllers/verifications_controller.rb
@@ -1,6 +1,7 @@
 class VerificationsController < ApplicationController
-  VERIFY_SID = Rails.application.credentials.twilio[:verify_sid]
   skip_before_action :enforce_verification
+
+  VERIFY_SID = Rails.application.credentials.dig(:twilio, :verify_sid)
 
   def index
   end

--- a/app/controllers/verifications_controller.rb
+++ b/app/controllers/verifications_controller.rb
@@ -1,5 +1,6 @@
 class VerificationsController < ApplicationController
   VERIFY_SID = Rails.application.credentials.twilio[:verify_sid]
+  skip_before_action :enforce_verification
 
   def index
   end
@@ -17,9 +18,10 @@ class VerificationsController < ApplicationController
     if check.status == 'approved'
       current_user.update(verified: true)
       flash[:notice] = 'Phone number has been verified!'
+      redirect_to root_path
     else
       flash[:notice] = 'Verification failed'
+      redirect_to verify_path
     end
-    redirect_to verify_path
   end
 end

--- a/app/javascript/src/application.scss
+++ b/app/javascript/src/application.scss
@@ -55,4 +55,3 @@ $fa-font-path: '~@fortawesome/fontawesome-free/webfonts';
 @import 'stylesheets/invites';
 @import '../components/blockouts/Scheduler';
 @import 'stylesheets/responsive_card_table';
-@import 'stylesheets/verifications'

--- a/app/javascript/src/stylesheets/verifications.scss
+++ b/app/javascript/src/stylesheets/verifications.scss
@@ -1,3 +1,0 @@
-input#code {
-  width: 6em;
-}

--- a/app/views/application/_nav.html.haml
+++ b/app/views/application/_nav.html.haml
@@ -6,7 +6,7 @@
           = image_pack_tag 'media/images/omd-logo-horiz.png', class: 'logo'
       .cell.auto.align-right.align-middle.grid-x
         - if user_signed_in?
-          - if policy(Need).new?
+          - if policy(Need).new? && !controller_name.in?(%w(registrations verifications))
             = link_to new_need_path, class: 'button success show-for-medium' do
               %fa.fas.fa-plus
               New Need

--- a/app/views/verifications/index.html.haml
+++ b/app/views/verifications/index.html.haml
@@ -1,26 +1,40 @@
-- content_for :page_header do
-  .header-text Phone verification
+.grid-x.grid-margin-x.align-middle.margin-top-3
+  .cell.auto
+  .cell.small-12.medium-9.large-6
+    .card
+      .card-divider
+        Phone verification
+      .card-section
+        - if current_user.verified?
+          %p
+            = "Your phone number (#{current_user.phone}) has already been verified."
+            %br
+            = link_to "Change my phone number", edit_user_registration_path 
+        - else
+          - if params[:verification_sent]
+            .callout.primary
+              %p Please submit the verification code you received via text message at #{current_user.phone}.
+            = form_tag(check_code_path) do
+              .grid-container
+                .grid-x.grid-padding-x
+                  .medium-4.cell
+                    = text_field_tag :code, nil, placeholder: 'Verification code'
+                  .cell.auto
+                    = submit_tag "Submit", class: 'primary button'
+              %small
+                Didn't receive a verification code?
+                = link_to 'Click here to try again.', verify_path
+          - else
+            .callout.warning
+              %p Please verify your phone number. Get started by clicking the 'Send verification code' button below. When you receive the verification code at #{current_user.phone}, submit it on the next screen.
+            %p
+              = "Your phone number: #{current_user.phone}"
+              %br
+              = link_to "Change my phone number", edit_user_registration_path
+            = link_to 'Send verification code', send_code_path, class: 'primary button', method: :post
+            .margin-top-1
+              %small
+                Already have a verification code?
+                = link_to 'Click here to enter it now.', verify_path(verification_sent: true)
 
-.grid-x.grid-padding-x.grid-margin-y
-  .cell
-    .actions
-      %p
-        For security, we need to verify that your phone number can receive
-        text messages. Please send yourself a verification code and then check
-        that it is correct upon receiving it.
-      %p
-        = "Your phone number: #{current_user.phone}"
-        %br
-        = link_to "Change my phone number", edit_user_registration_path
-      %p
-        Your verification status:
-        %strong= current_user.verified? ? 'Verified' : 'Unverified'
-      = form_tag(send_code_path) do
-        %p
-          = submit_tag "Send verification code"
-
-      = form_tag(check_code_path) do
-        %p
-          = label_tag :code
-          = text_field_tag :code
-          = submit_tag "Check verification code"
+  .cell.auto

--- a/app/views/verifications/index.html.haml
+++ b/app/views/verifications/index.html.haml
@@ -5,6 +5,10 @@
   .cell
     .actions
       %p
+        For security, we need to verify that your phone number can receive
+        text messages. Please send yourself a verification code and then check
+        that it is correct upon receiving it.
+      %p
         = "Your phone number: #{current_user.phone}"
         %br
         = link_to "Change my phone number", edit_user_registration_path

--- a/spec/controllers/application_controller_spec.rb
+++ b/spec/controllers/application_controller_spec.rb
@@ -18,12 +18,11 @@ RSpec.describe ApplicationController, type: :controller do
       it { is_expected.to redirect_to(verify_path) }
 
       context 'when in a Devise controller' do
-        before {
-          # It needs to return false the first two times or will error out
-          expect(controller).to receive(:devise_controller?).exactly(:twice).
-            and_call_original
-          expect(controller).to receive(:devise_controller?) { true }
-        }
+        before do
+          allow(controller).to receive(:devise_controller?).and_return(true)
+          allow(controller).to receive(:configure_permitted_parameters)
+        end
+
         it { is_expected.not_to redirect_to(verify_path) }
       end
     end

--- a/spec/controllers/application_controller_spec.rb
+++ b/spec/controllers/application_controller_spec.rb
@@ -3,4 +3,34 @@
 require 'rails_helper'
 
 RSpec.describe ApplicationController, type: :controller do
+  controller do
+    def index
+      head :ok
+    end
+  end
+
+  describe 'before_filter :enforce_verification' do
+    subject { get :index }
+    before { sign_in(user) }
+
+    context 'when user is not verified' do
+      let(:user) { create(:user, verified: false) }
+      it { is_expected.to redirect_to(verify_path) }
+
+      context 'when in a Devise controller' do
+        before {
+          # It needs to return false the first two times or will error out
+          expect(controller).to receive(:devise_controller?).exactly(:twice).
+            and_call_original
+          expect(controller).to receive(:devise_controller?) { true }
+        }
+        it { is_expected.not_to redirect_to(verify_path) }
+      end
+    end
+
+    context 'when user is verified' do
+      let(:user) { create(:user) }
+      it { is_expected.not_to redirect_to(verify_path) }
+    end
+  end
 end

--- a/spec/controllers/verifications_controller_spec.rb
+++ b/spec/controllers/verifications_controller_spec.rb
@@ -1,13 +1,12 @@
 require 'rails_helper'
 
 RSpec.describe VerificationsController, type: :controller do
-  let(:user) { create(:user) }
+  let(:user) { create(:user, verified: false) }
   before { sign_in user }
 
   describe '#index' do
     it 'returns ok' do
       get :index
-
       expect(response).to have_http_status(:ok)
     end
   end
@@ -39,7 +38,7 @@ RSpec.describe VerificationsController, type: :controller do
         user.reload
         expect(user.verified?).to be true
         expect(flash[:notice]).to eq 'Phone number has been verified!'
-        expect(response).to redirect_to(verify_path)
+        expect(response).to redirect_to(root_path)
       end
     end
 

--- a/spec/controllers/verifications_controller_spec.rb
+++ b/spec/controllers/verifications_controller_spec.rb
@@ -17,7 +17,7 @@ RSpec.describe VerificationsController, type: :controller do
         :verify, :services, :verifications, :create
       )
       post :send_code
-      expect(response).to redirect_to(verify_path)
+      expect(response).to redirect_to(verify_path(verification_sent: true))
     end
   end
 

--- a/spec/controllers/verifications_controller_spec.rb
+++ b/spec/controllers/verifications_controller_spec.rb
@@ -17,7 +17,6 @@ RSpec.describe VerificationsController, type: :controller do
         :verify, :services, :verifications, :create
       )
       post :send_code
-      expect(flash[:notice]).to eq 'Verification code has been sent'
       expect(response).to redirect_to(verify_path)
     end
   end

--- a/spec/factories/users.rb
+++ b/spec/factories/users.rb
@@ -28,6 +28,8 @@ FactoryBot.define do
     first_language_id { 1 }
     age_range_ids { [1] }
 
+    verified { true }
+
     after :build do |user|
       user.offices << build(:wa_office) unless user.offices.any?
     end


### PR DESCRIPTION
Only affects signed in users.
Does not affect users on a Devise controller.
Does not affect users in the Verifications controller.
Now redirects to root_path upon successful verification.
Additional text added to the verify page to explain its purpose and make
it less unpleasant.
The users factory will now default verified to true.
Appropriate specs added for ApplicationController.

Implements #200 