### PR TITLE
Explicitly exclude Haml files from Rubocop

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -15,6 +15,7 @@ AllCops:
     - 'script/**/*'
     - 'spec/**/*'
     - 'vendor/**/*'
+    - '**/*.haml'
 
 Metrics/BlockLength:
   Exclude:


### PR DESCRIPTION
This solves the issue where Haml files were being run through rubocop in
Atom.