### PR TITLE
Don't enforce Block Length cop on specs

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -19,6 +19,7 @@ AllCops:
 Metrics/BlockLength:
   Exclude:
     - 'lib/tasks/**/*'
+    - 'spec/**/*'
 
 Metrics/ClassLength:
   Max: 150


### PR DESCRIPTION
It's poorly suited to handle RSpec. See this discussion on the issue,
which recommends disabling this cop for specs.
https://stackoverflow.com/questions/40934345/rubocop-25-line-block-size-and-rspec-tests