### PR TITLE
Notify social workers, coordinators, and admins of shift changes, with opt-out

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -19,6 +19,7 @@ AllCops:
 Metrics/BlockLength:
   Exclude:
     - 'lib/tasks/**/*'
+    - 'spec/**/*'
 
 Metrics/ClassLength:
   Max: 150

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -22,4 +22,7 @@ Metrics/BlockLength:
     - 'spec/**/*'
 
 Metrics/ClassLength:
-  Max: 150
+  Max: 200
+
+Rails/HasAndBelongsToMany:
+  Enabled: false

--- a/app/lib/includers/shift_update_event_helper.rb
+++ b/app/lib/includers/shift_update_event_helper.rb
@@ -3,6 +3,7 @@
 module ShiftUpdateEventHelper
   # This module relies on the following variables being declared and present:
   # current_user, need, user, user_was
+  NOTIFIABLE_ROLES = [User::ADMIN, User::COORDINATOR, User::SOCIAL_WORKER].freeze
 
   def shift_user_is_current_user?
     user.present? && user.eql?(current_user)
@@ -20,12 +21,13 @@ module ShiftUpdateEventHelper
     current_user.scheduler? && user.nil?
   end
 
-  def social_workers_and_need_user
-    social_workers | [need.user]
+  def notifiable_office_users_and_need_user
+    notifiable_office_users | [need.user]
   end
 
-  def social_workers
-    need.office.users.social_workers
+  def notifiable_office_users
+    need.office.users.joins(:office_users).where('role IN (?)', NOTIFIABLE_ROLES)
+      .where(office_users: { send_notifications: true }).to_a
   end
 
 end

--- a/app/lib/services/notifications/shifts/recipients/update.rb
+++ b/app/lib/services/notifications/shifts/recipients/update.rb
@@ -14,10 +14,10 @@ module Services
 
           def recipients
             if shift_user_is_current_user? || current_user_left_shift?
-              return social_workers_and_need_user
+              return notifiable_office_users | [need.user]
             end
-            return [user] if scheduler_with_user?
-            return [user_was] if scheduler_without_user?
+            return notifiable_office_users | [need.user, user] if scheduler_with_user?
+            return notifiable_office_users | [need.user, user_was] if scheduler_without_user?
 
             []
           end

--- a/app/lib/services/notifications/shifts/recipients/update.rb
+++ b/app/lib/services/notifications/shifts/recipients/update.rb
@@ -14,10 +14,10 @@ module Services
 
           def recipients
             if shift_user_is_current_user? || current_user_left_shift?
-              return notifiable_office_users | [need.user]
+              return notifiable_office_users_and_need_user
             end
-            return notifiable_office_users | [need.user, user] if scheduler_with_user?
-            return notifiable_office_users | [need.user, user_was] if scheduler_without_user?
+            return notifiable_office_users_and_need_user | [user] if scheduler_with_user?
+            return notifiable_office_users_and_need_user | [user_was] if scheduler_without_user?
 
             []
           end

--- a/app/models/office.rb
+++ b/app/models/office.rb
@@ -2,8 +2,9 @@
 
 class Office < ApplicationRecord
   has_one :address, as: :addressable, dependent: :destroy
-  has_and_belongs_to_many :users
   has_many :needs, dependent: :destroy
+  has_many :office_users
+  has_many :users, through: :office_users
   validates :name, :address, presence: true
   validates :region, numericality: { only_integer: true }
 

--- a/app/models/office.rb
+++ b/app/models/office.rb
@@ -3,7 +3,7 @@
 class Office < ApplicationRecord
   has_one :address, as: :addressable, dependent: :destroy
   has_many :needs, dependent: :destroy
-  has_many :office_users
+  has_many :office_users, dependent: :destroy
   has_many :users, through: :office_users
   validates :name, :address, presence: true
   validates :region, numericality: { only_integer: true }

--- a/app/models/office_user.rb
+++ b/app/models/office_user.rb
@@ -3,4 +3,5 @@
 class OfficeUser < ApplicationRecord
   belongs_to :office
   belongs_to :user
+  scope :notifiable, -> { where(send_notifications: true) }
 end

--- a/app/models/office_user.rb
+++ b/app/models/office_user.rb
@@ -1,0 +1,6 @@
+# frozen_string_literal: true
+
+class OfficeUser < ApplicationRecord
+  belongs_to :office
+  belongs_to :user
+end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -185,7 +185,7 @@ class User < ApplicationRecord
   end
 
   def office_notification_ids
-    office_users.notifiable.pluck(:id)
+    office_users.notifiable.pluck(:office_id)
   end
 
 

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -177,7 +177,7 @@ class User < ApplicationRecord
   end
 
   def role_display
-    I18n.t("user.roles.#{role}", default: ->(_args) { role.titleize })
+    I18n.t("user.roles.#{role}", default: ->(*_args) { role.titleize })
   end
 
   # standard E.164 format used by Twilio

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -190,7 +190,7 @@ class User < ApplicationRecord
   end
 
   def office_notification_ids=(ids)
-    ids = ids.map(&:to_i)
+    ids = ids.reject(&:blank?).map(&:to_i)
     office_users.each do |ou|
       ou.update!(send_notifications: ou.office_id.in?(ids))
     end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -27,7 +27,8 @@ class User < ApplicationRecord
                    :medical_limitations,
                    :medical_limitations_desc,
                    :conviction,
-                   :conviction_desc].freeze
+                   :conviction_desc,
+                   { office_notification_ids: [] }].freeze
 
   has_one :address, as: :addressable, dependent: :destroy
   has_many :blockouts, dependent: :destroy
@@ -181,6 +182,18 @@ class User < ApplicationRecord
 
   def e164_phone # standard E.164 format used by Twilio
     '+1' + phone.gsub(/\D/, '')
+  end
+
+  def office_notification_ids
+    office_users.notifiable.pluck(:id)
+  end
+
+
+  def office_notification_ids=(ids)
+    ids = ids.map(&:to_i)
+    office_users.each do |ou|
+      ou.update!(send_notifications: ou.office_id.in?(ids))
+    end
   end
 
   private

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -88,7 +88,7 @@ class User < ApplicationRecord
             if:       -> { require_volunteer_profile_attributes? && conviction? }
 
   validates :role,
-            inclusion: { in: ROLES, message: '%{value} is not a valid role' }
+            inclusion: { in: ROLES, message: '%<value> is not a valid role' }
   validates :time_zone, presence: true, if: :invitation_accepted_at?
   validate :at_least_one_office
   validate :at_least_one_age_range,
@@ -177,17 +177,17 @@ class User < ApplicationRecord
   end
 
   def role_display
-    I18n.t("user.roles.#{role}", default: -> (*args) { role.titleize })
+    I18n.t("user.roles.#{role}", default: -> { role.titleize })
   end
 
-  def e164_phone # standard E.164 format used by Twilio
+  # standard E.164 format used by Twilio
+  def e164_phone
     '+1' + phone.gsub(/\D/, '')
   end
 
   def office_notification_ids
     office_users.notifiable.pluck(:office_id)
   end
-
 
   def office_notification_ids=(ids)
     ids = ids.map(&:to_i)
@@ -203,8 +203,8 @@ class User < ApplicationRecord
   end
 
   def check_phone_verification
-    if phone_changed? && phone_was.present?
-      self.verified = false
-    end
+    return unless phone_changed? && phone_was.present?
+
+    self.verified = false
   end
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -177,7 +177,7 @@ class User < ApplicationRecord
   end
 
   def role_display
-    I18n.t("user.roles.#{role}", default: -> { role.titleize })
+    I18n.t("user.roles.#{role}", default: ->(_args) { role.titleize })
   end
 
   # standard E.164 format used by Twilio

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -40,7 +40,7 @@ class User < ApplicationRecord
            through:    :shifts,
            class_name: 'Need',
            source:     'need'
-  has_many :office_users
+  has_many :office_users, dependent: :destroy
   has_many :offices, through: :office_users
   has_and_belongs_to_many :social_worker_needs, class_name: 'Need',
     join_table: 'needs_social_workers', foreign_key: 'social_worker_id',

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -30,7 +30,6 @@ class User < ApplicationRecord
                    :conviction_desc].freeze
 
   has_one :address, as: :addressable, dependent: :destroy
-  has_and_belongs_to_many :offices
   has_many :blockouts, dependent: :destroy
   belongs_to :race, optional: true
   has_and_belongs_to_many :age_ranges
@@ -40,6 +39,8 @@ class User < ApplicationRecord
            through:    :shifts,
            class_name: 'Need',
            source:     'need'
+  has_many :office_users
+  has_many :offices, through: :office_users
   has_and_belongs_to_many :social_worker_needs, class_name: 'Need',
     join_table: 'needs_social_workers', foreign_key: 'social_worker_id',
     association_foreign_key: 'need_id'

--- a/app/views/devise/shared/_profile_fields.html.haml
+++ b/app/views/devise/shared/_profile_fields.html.haml
@@ -87,6 +87,15 @@
                required: true
     .help-text Required
 
+.grid-x.grid-padding-x.grid-margin-y
+  .cell
+    = f.label :office_notification_ids do
+      I want to receive notifications for any requests sent for
+    = f.select :office_notification_ids,
+              f.object.offices.map { |o| [o.name, o.id] },
+              {},
+              { multiple: true, class: 'multiple' }
+
 - if profile_attributes_required?(resource)
   .grid-x.grid-padding-x.grid-margin-y
     .cell

--- a/db/migrate/20191219190855_create_office_users.rb
+++ b/db/migrate/20191219190855_create_office_users.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+class CreateOfficeUsers < ActiveRecord::Migration[6.0]
+  def change
+    rename_table :offices_users, :office_users
+    change_table :office_users, bulk: true do |t|
+      t.primary_key :id
+      t.boolean :send_notifications, default: false, null: false
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2019_12_09_221008) do
+ActiveRecord::Schema.define(version: 2019_12_19_190855) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -95,16 +95,17 @@ ActiveRecord::Schema.define(version: 2019_12_09_221008) do
     t.index ["social_worker_id"], name: "index_needs_social_workers_on_social_worker_id"
   end
 
+  create_table "office_users", force: :cascade do |t|
+    t.bigint "office_id", null: false
+    t.bigint "user_id", null: false
+    t.boolean "send_notifications", default: false, null: false
+  end
+
   create_table "offices", force: :cascade do |t|
     t.string "name"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.integer "region", default: 0, null: false
-  end
-
-  create_table "offices_users", id: false, force: :cascade do |t|
-    t.bigint "office_id", null: false
-    t.bigint "user_id", null: false
   end
 
   create_table "races", force: :cascade do |t|

--- a/spec/factories/office_users.rb
+++ b/spec/factories/office_users.rb
@@ -1,0 +1,5 @@
+FactoryBot.define do
+  factory :office_user do
+    
+  end
+end

--- a/spec/factories/office_users.rb
+++ b/spec/factories/office_users.rb
@@ -1,5 +1,8 @@
+# frozen_string_literal: true
+
 FactoryBot.define do
   factory :office_user do
-    
+    association :user
+    association :office
   end
 end

--- a/spec/lib/includers/shift_update_event_helper_spec.rb
+++ b/spec/lib/includers/shift_update_event_helper_spec.rb
@@ -9,11 +9,13 @@ RSpec.describe ShiftUpdateEventHelper do
   let(:volunteer1) { create(:user, offices: [shift.office]) }
   let(:volunteer2) { create(:user, offices: [shift.office]) }
   let(:object) do
-    double(Shift,
-           current_user: volunteer1,
-           user_was:     nil,
-           need:         need,
-           user:         shift.user).extend(described_class)
+    instance_double(
+      Services::Notifications::Shifts::Recipients::Update,
+      current_user: volunteer1,
+      user_was:     nil,
+      need:         need,
+      user:         shift.user
+    ).extend(described_class)
   end
   let(:social_worker1) do
     volunteer1.tap { |v| v.update!(role: User::SOCIAL_WORKER) }

--- a/spec/lib/includers/shift_update_event_helper_spec.rb
+++ b/spec/lib/includers/shift_update_event_helper_spec.rb
@@ -6,22 +6,27 @@ RSpec.describe ShiftUpdateEventHelper do
 
   let(:shift) { create(:shift) }
   let(:need) { shift.need }
-  let(:volunteer1) { create(:user, offices: [shift.office]) }
-  let(:volunteer2) { create(:user, offices: [shift.office]) }
+  let(:current_user) { volunteer }
   let(:object) do
     instance_double(
       Services::Notifications::Shifts::Recipients::Update,
-      current_user: volunteer1,
+      current_user: current_user,
       user_was:     nil,
       need:         need,
       user:         shift.user
     ).extend(described_class)
   end
-  let(:social_worker1) do
-    volunteer1.tap { |v| v.update!(role: User::SOCIAL_WORKER) }
-  end
-  let(:social_worker2) do
-    volunteer2.tap { |v| v.update!(role: User::SOCIAL_WORKER) }
+  let(:volunteer)       { create(:user, offices: [shift.office], role: User::VOLUNTEER) }
+  let(:social_worker)   { create(:user, offices: [shift.office], role: User::SOCIAL_WORKER) }
+  let(:coordinator)     { create(:user, offices: [shift.office], role: User::COORDINATOR) }
+  let(:admin)           { create(:user, offices: [shift.office], role: User::ADMIN) }
+  let(:non_notifiable)  { create(:user, offices: [shift.office], role: User::SOCIAL_WORKER) }
+
+  before do
+    [volunteer, social_worker, coordinator, admin].each do |user|
+      office_user = OfficeUser.where(user: user, office: shift.office).first
+      office_user.update!(send_notifications: true)
+    end
   end
 
   describe '#shift_user_is_current_user?' do
@@ -32,7 +37,7 @@ RSpec.describe ShiftUpdateEventHelper do
     end
 
     it 'returns true when shift user is current user' do
-      shift.user = volunteer1
+      shift.user = volunteer
       shift.save!
 
       result = object.shift_user_is_current_user?
@@ -41,7 +46,7 @@ RSpec.describe ShiftUpdateEventHelper do
     end
 
     it 'returns false when current user is not shift user' do
-      allow(object).to receive(:current_user).and_return(volunteer2)
+      allow(object).to receive(:current_user).and_return(social_worker)
 
       result = object.shift_user_is_current_user?
 
@@ -65,7 +70,7 @@ RSpec.describe ShiftUpdateEventHelper do
     end
 
     it 'returns false if user_was is not current_user' do
-      allow(object).to receive(:user_was).and_return(volunteer2)
+      allow(object).to receive(:user_was).and_return(social_worker)
 
       result = object.current_user_left_shift?
 
@@ -82,7 +87,7 @@ RSpec.describe ShiftUpdateEventHelper do
 
     it 'returns true if user nil, and current_user is user_was' do
       allow(object).to receive(:user).and_return(nil)
-      allow(object).to receive(:user_was).and_return(volunteer1)
+      allow(object).to receive(:user_was).and_return(volunteer)
 
       result = object.current_user_left_shift?
 
@@ -90,7 +95,7 @@ RSpec.describe ShiftUpdateEventHelper do
     end
 
     it 'returns true if user present and current_user is user_was' do
-      allow(object).to receive(:user_was).and_return(volunteer1)
+      allow(object).to receive(:user_was).and_return(volunteer)
 
       result = object.current_user_left_shift?
 
@@ -109,7 +114,7 @@ RSpec.describe ShiftUpdateEventHelper do
       end
 
       it 'returns false if shift assigned' do
-        shift.user = volunteer2
+        shift.user = coordinator
         shift.save!
 
         result = object.scheduler_with_user?
@@ -119,9 +124,7 @@ RSpec.describe ShiftUpdateEventHelper do
     end
 
     context 'when current_user is a scheduler' do
-      before do
-        volunteer1.update!(role: User::COORDINATOR)
-      end
+      let(:current_user) { coordinator }
 
       it 'returns false if shift not assigned' do
         allow(object).to receive(:user).and_return(nil)
@@ -132,7 +135,7 @@ RSpec.describe ShiftUpdateEventHelper do
       end
 
       it 'returns true if shift assigned' do
-        shift.user = volunteer2
+        shift.user = coordinator
         shift.save!
 
         result = object.scheduler_with_user?
@@ -153,7 +156,7 @@ RSpec.describe ShiftUpdateEventHelper do
       end
 
       it 'returns false if shift assigned' do
-        shift.user = volunteer2
+        shift.user = coordinator
         shift.save!
 
         result = object.scheduler_without_user?
@@ -163,9 +166,7 @@ RSpec.describe ShiftUpdateEventHelper do
     end
 
     context 'when current_user is a scheduler' do
-      before do
-        volunteer1.update!(role: User::COORDINATOR)
-      end
+      let(:current_user) { coordinator }
 
       it 'returns true if shift not assigned' do
         allow(object).to receive(:user).and_return(nil)
@@ -176,7 +177,7 @@ RSpec.describe ShiftUpdateEventHelper do
       end
 
       it 'returns false if shift assigned' do
-        shift.user = volunteer2
+        shift.user = social_worker
         shift.save!
 
         result = object.scheduler_without_user?
@@ -186,42 +187,19 @@ RSpec.describe ShiftUpdateEventHelper do
     end
   end
 
-  describe '#social_workers_and_need_user' do
-    it 'returns need user and all social workers associated with the office' do
-      volunteer1.update!(role: User::SOCIAL_WORKER)
-      volunteer2.update!(role: User::SOCIAL_WORKER)
+  describe '#notifiable_office_users_and_need_user' do
+    it 'returns need user and all notifiable office users associated with the office' do
+      result = object.notifiable_office_users_and_need_user
 
-      result = object.social_workers_and_need_user
-
-      expect(result).to match_array([volunteer1, volunteer2, need.user])
-    end
-
-    it 'returns need user if no social workers' do
-      result = object.social_workers_and_need_user
-
-      expect(result).to match_array([need.user])
+      expect(result).to match_array([social_worker, coordinator, admin, need.user])
     end
   end
 
-  describe '#social_workers' do
-    before do
-      need.user.update!(role: User::VOLUNTEER)
-    end
+  describe '#notifiable_office_users' do
+    it 'returns all notifiable office users associated with the office' do
+      result = object.notifiable_office_users
 
-    it 'returns all social workers associated with the office' do
-      social_worker1
-      social_worker2
-
-      result = object.social_workers
-
-      expect(result).to match_array([social_worker1, social_worker2])
-    end
-
-    it 'returns empty collection if no social workers' do
-      result = object.social_workers
-
-      expect(result).to match_array([])
+      expect(result).to match_array([social_worker, coordinator, admin])
     end
   end
-
 end

--- a/spec/models/office_user_spec.rb
+++ b/spec/models/office_user_spec.rb
@@ -1,0 +1,5 @@
+require 'rails_helper'
+
+RSpec.describe OfficeUser, type: :model do
+  pending "add some examples to (or delete) #{__FILE__}"
+end

--- a/spec/models/office_user_spec.rb
+++ b/spec/models/office_user_spec.rb
@@ -1,5 +1,11 @@
+# frozen_string_literal: true
+
 require 'rails_helper'
 
 RSpec.describe OfficeUser, type: :model do
-  pending "add some examples to (or delete) #{__FILE__}"
+  let(:office_user) { build(:office_user) }
+
+  it 'has a valid factory' do
+    expect(office_user.valid?).to be(true)
+  end
 end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -368,17 +368,15 @@ RSpec.describe User, type: :model do
   end
 
   describe '#office_notification_ids=' do
-    let!(:office2) { create(:office) }
-    let(:office_user) { user.office_users.first }
-    let!(:office_user2) do
-      create(:office_user, user: user, office: office2, send_notifications: false)
-    end
+    let(:office2) { create(:office) }
+    let(:office_user1) { user.office_users.first }
+    let!(:office_user2) { create(:office_user, user: user, office: office2) }
 
-    it 'sends send_notifications to true for office_users with passed office ids' do
-      expect(office_user.send_notifications?).to be false
+    it 'sets send_notifications to true for office_users with passed office ids' do
+      expect(office_user1.send_notifications?).to be false
       expect(office_user2.send_notifications?).to be false
       user.office_notification_ids = [office2.id.to_s]
-      expect(office_user.reload.send_notifications?).to be false
+      expect(office_user1.reload.send_notifications?).to be false
       expect(office_user2.reload.send_notifications?).to be true
     end
   end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -37,13 +37,13 @@ RSpec.describe User, type: :model do
   end
 
   describe '#name' do
-    context 'first & last name are present' do
+    context 'when first & last name are present' do
       it 'returns first & last name' do
         expect(user.name).to eq('Test User')
       end
     end
 
-    context 'first & last name are nil' do
+    context 'when first & last name are nil' do
       it 'returns email address' do
         user.assign_attributes(first_name: nil, last_name: nil)
         expect(user.name).to eq(user.email)
@@ -52,11 +52,11 @@ RSpec.describe User, type: :model do
   end
 
   describe '.exclude_blockouts' do
-    subject { User.exclude_blockouts(*time.values) }
+    subject { described_class.exclude_blockouts(*time.values) }
 
     let(:time) { { start_at: 1.day.from_now, end_at: 1.day.from_now + 1.hour } }
 
-    context 'user has no blockouts' do
+    context 'when user has no blockouts' do
       let!(:user) { create :user }
 
       it 'includes the user' do
@@ -64,7 +64,7 @@ RSpec.describe User, type: :model do
       end
     end
 
-    context 'user has blockouts with overlap' do
+    context 'when user has blockouts with overlap' do
       let(:user) { build :user }
       let!(:blockout) { create :blockout, user: user, **time }
 
@@ -73,7 +73,7 @@ RSpec.describe User, type: :model do
       end
     end
 
-    context 'user has blockouts with no overlap' do
+    context 'when user has blockouts with no overlap' do
       let(:user) { build :user }
       let!(:blockout) do
         create(:blockout,
@@ -89,7 +89,7 @@ RSpec.describe User, type: :model do
   end
 
   describe '.speaks_language' do
-    subject { User.speaks_language(language) }
+    subject { described_class.speaks_language(language) }
 
     let(:language) { create :language }
 
@@ -131,7 +131,7 @@ RSpec.describe User, type: :model do
     end
   end
 
-  context 'reporting' do
+  context 'when reporting' do
     let(:lang1) { create(:language, name: 'Lang1') }
     let(:lang2) { create(:language, name: 'Lang2') }
     let(:lang3) { create(:language, name: 'Lang3') }
@@ -214,7 +214,7 @@ RSpec.describe User, type: :model do
     before do
       or_need.shifts.first.update(user: or_user)
       wa_need1.shifts.first.update(user: wa_user1)
-      wa_need2.shifts.update_all(user_id: wa_user2.id)
+      wa_need2.shifts.find_each { |s| s.update!(user_id: wa_user2.id) }
       wa_need3.shifts.first.update(user: wa_user3)
       wa_need3.shifts.last.update(user: wa_user2)
     end
@@ -310,6 +310,7 @@ RSpec.describe User, type: :model do
       user.first_name = 'Santa'
       user.last_name  = 'Claus'
     end
+
     it 'to_s' do
       result = user.to_s
 

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -355,4 +355,31 @@ RSpec.describe User, type: :model do
       expect(user.e164_phone).to eq('+13606107089')
     end
   end
+
+  describe '#office_notification_ids' do
+    let!(:office2) { create(:office) }
+    let!(:office_user2) do
+      create(:office_user, user: user, office: office2, send_notifications: true)
+    end
+
+    it 'returns office ids where office_user has send_notifications set to true' do
+      expect(user.office_notification_ids).to eq([office2.id])
+    end
+  end
+
+  describe '#office_notification_ids=' do
+    let!(:office2) { create(:office) }
+    let(:office_user) { user.office_users.first }
+    let!(:office_user2) do
+      create(:office_user, user: user, office: office2, send_notifications: false)
+    end
+
+    it 'sends send_notifications to true for office_users with passed office ids' do
+      expect(office_user.send_notifications?).to be false
+      expect(office_user2.send_notifications?).to be false
+      user.office_notification_ids = [office2.id.to_s]
+      expect(office_user.reload.send_notifications?).to be false
+      expect(office_user2.reload.send_notifications?).to be true
+    end
+  end
 end

--- a/spec/policies/user_policy_spec.rb
+++ b/spec/policies/user_policy_spec.rb
@@ -7,17 +7,7 @@ RSpec.describe UserPolicy, type: :policy do
   let(:user) { build(:user) }
   let(:other_user) { build(:user) }
 
-  let(:attributes) do
-    [
-      :birth_date, :conviction, :conviction_desc, :discovered_omd_by,
-      :email, :first_language_id, :second_language_id, :first_name,
-      :last_name, :medical_limitations, :medical_limitations_desc,
-      :phone, :race_id, :resident_since, :time_zone,
-      { age_range_ids: [] },
-      { office_ids: [] },
-      { office_notification_ids: [] }
-    ]
-  end
+  let(:attributes) { User::PROFILE_ATTRS | [:email, { office_ids: [] }] }
 
   describe '#new?' do
     context 'when an admin' do

--- a/spec/policies/user_policy_spec.rb
+++ b/spec/policies/user_policy_spec.rb
@@ -7,6 +7,18 @@ RSpec.describe UserPolicy, type: :policy do
   let(:user) { build(:user) }
   let(:other_user) { build(:user) }
 
+  let(:attributes) do
+    [
+      :birth_date, :conviction, :conviction_desc, :discovered_omd_by,
+      :email, :first_language_id, :second_language_id, :first_name,
+      :last_name, :medical_limitations, :medical_limitations_desc,
+      :phone, :race_id, :resident_since, :time_zone,
+      { age_range_ids: [] },
+      { office_ids: [] },
+      { office_notification_ids: [] }
+    ]
+  end
+
   describe '#new?' do
     context 'when an admin' do
       let(:user) { build(:user, role: 'admin') }
@@ -93,24 +105,7 @@ RSpec.describe UserPolicy, type: :policy do
     it 'permitted_attributes_for_create' do
       result = subject.permitted_attributes_for_create
 
-      expect(result).to match_array([:birth_date,
-                                     :conviction,
-                                     :conviction_desc,
-                                     :discovered_omd_by,
-                                     :email,
-                                     :first_language_id,
-                                     :second_language_id,
-                                     :first_name,
-                                     :last_name,
-                                     :medical_limitations,
-                                     :medical_limitations_desc,
-                                     :phone,
-                                     :race_id,
-                                     :resident_since,
-                                     :role,
-                                     :time_zone,
-                                     { age_range_ids: [] },
-                                     { office_ids: [] }])
+      expect(result).to match_array(attributes | [:role])
     end
   end
 
@@ -118,31 +113,15 @@ RSpec.describe UserPolicy, type: :policy do
     it 'permitted_attributes' do
       result = subject.permitted_attributes
 
-      expect(result).to match_array([:birth_date,
-                                     :conviction,
-                                     :conviction_desc,
-                                     :discovered_omd_by,
-                                     :email,
-                                     :first_language_id,
-                                     :second_language_id,
-                                     :first_name,
-                                     :last_name,
-                                     :medical_limitations,
-                                     :medical_limitations_desc,
-                                     :phone,
-                                     :race_id,
-                                     :resident_since,
-                                     :time_zone,
-                                     { age_range_ids: [] },
-                                     { office_ids: [] }])
+      expect(result).to match_array(attributes)
     end
   end
 
   # TODO: auto-generated
   describe '#permitted_attributes_for_account_update' do
     it 'permitted_attributes_for_account_update' do
-      user        = double('user')
-      other_user  = double('other_user')
+      user        = instance_double(User, 'user')
+      other_user  = instance_double(User, 'other_user')
       user_policy = described_class.new(user, other_user)
       result      = user_policy.permitted_attributes_for_account_update
 


### PR DESCRIPTION
Implements #189.

This PR includes the following:

- The creation of a new join model, OfficeUser, which replaces the old habtm `offices_users` table. It has a boolean attribute, `send_notifications`.
- A new multi-select is added to the Edit Profile page which allows users to choose which offices they want to receive shift notifications from.
- When a shift is assigned or unassigned, notify social workers, coordinators, and admins via text message, so long as they have marked themselves as notifiable in this office. Unlike before, it will notify these users whether a shift is changed via a scheduler or the volunteer themselves.
- The Rubocop config change found in #364 
- Rubocop updates to relevant spec files.
