### PR TITLE
Fix some social worker selection issues

### DIFF
--- a/app/views/needs/office_social_workers.html.haml
+++ b/app/views/needs/office_social_workers.html.haml
@@ -1,5 +1,6 @@
 - if office.present? && office.users.social_workers.any?
   - selected = @need.present? ? @need.social_worker_ids : nil
-  = select_tag "need[social_worker_ids]", options_from_collection_for_select(office.users.social_workers, :id, :name, selected), { include_blank: false, multiple: true }
+  = hidden_field_tag "need[social_worker_ids][]", ""
+  = select_tag "need[social_worker_ids]", options_from_collection_for_select(office.users.social_workers, :id, :name, selected), { include_blank: false, multiple: true, class: "multiple" }
 - else
   = select_tag "need[social_worker_ids]", [], disabled: true


### PR DESCRIPTION
The proper select2 CSS styling wasn't working because I didn't add the class.
It used to be impossible to set there to be NO social workers after one was set; adding a hidden field fixes that.