### PR TITLE
Enable cache_classes in test mode

### DIFF
--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -6,7 +6,7 @@
 Rails.application.configure do
   # Settings specified here will take precedence over those in config/application.rb.
 
-  config.cache_classes = false
+  config.cache_classes = true
 
   # Do not eager load code on boot. This avoids loading your whole application
   # just for the purpose of running a single test. If you are using a tool that


### PR DESCRIPTION
It's default, makes tests faster, and avoids some constant redefinition warnings.