### PR TITLE
Validate that start_at is not midnight

### DIFF
--- a/spec/models/need_spec.rb
+++ b/spec/models/need_spec.rb
@@ -219,4 +219,13 @@ RSpec.describe Need, type: :model do
     it { is_expected.to eq([pending_user]) }
   end
 
+  describe 'validates :intentional_start_at' do
+    before { need.start_at = need.start_at.midnight }
+
+    it 'adds a validation error when start_at is midnight' do
+      expect(need.valid?).to be false
+      expect(need.errors[:start_at]).to eq ['must not be midnight']
+    end
+  end
+
 end


### PR DESCRIPTION
Midnight is the default time selection, however this time is very unlikely, so we want
to force the user to select a more appropriate time.

Add appropriate spec.

Tested in development mode.