### PR TITLE
Upgrade to Node 12

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -5,7 +5,7 @@ x-ruby: &ruby-base
     context: ./docker/ruby
     args:
       - RUBY_VERSION=2.6.5
-      - NODE_VERSION=11
+      - NODE_VERSION=12
       - INSTALL_PG_CLIENT=true
       - UID=${UID}
       - GID=${GID}

--- a/docker/ruby/Dockerfile
+++ b/docker/ruby/Dockerfile
@@ -2,7 +2,7 @@ ARG RUBY_VERSION=2.6
 
 FROM ruby:$RUBY_VERSION
 
-ARG NODE_VERSION=11
+ARG NODE_VERSION=12
 
 RUN curl -sL https://deb.nodesource.com/setup_$NODE_VERSION.x | bash -
 

--- a/package.json
+++ b/package.json
@@ -1,5 +1,8 @@
 {
   "name": "scheduler",
+  "engines": {
+    "node": "12.x"
+  },
   "private": true,
   "scripts": {
     "test": "jest --config=jest.config.js"


### PR DESCRIPTION
Node 11 gives deprecation warnings. 12 is the current LTS version. 14 is
actually the latest version right now.