### PR TITLE
Filter notifiable users in reminder notifications

### DIFF
--- a/app/models/need.rb
+++ b/app/models/need.rb
@@ -77,7 +77,7 @@ class Need < ApplicationRecord
   end
 
   def users_pending_response
-    User.find(notified_user_ids - unavailable_user_ids - shifts.pluck(:user_id))
+    User.notifiable.find(notified_user_ids - unavailable_user_ids - shifts.pluck(:user_id))
   end
 
   private


### PR DESCRIPTION
Ensure reminder notifications are sent only to notifiable users.

The user affected by the bug @nshoes fixed in #523 received a reminder notification around noon today. This should fix that!