### PR TITLE
Hotfix for users_pending_response

### DIFF
--- a/app/models/need.rb
+++ b/app/models/need.rb
@@ -77,7 +77,7 @@ class Need < ApplicationRecord
   end
 
   def users_pending_response
-    User.notifiable.find(notified_user_ids - unavailable_user_ids - shifts.pluck(:user_id))
+    User.notifiable.where(id: notified_user_ids - unavailable_user_ids - shifts.pluck(:user_id))
   end
 
   private


### PR DESCRIPTION
We can't use find here. If one of the users is excluded by the notifiable scope, we'll get a record not found error.