### PR TITLE
Add mutant license key

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -101,9 +101,16 @@ group :development do
 end
 
 group :test do
+  # Mutant license key is scoped to
+  # https://github.com/OfficeMomsandDads/scheduler
+  # and will not be useful elsewhere
+  source 'https://oss:FwSfIZqXnuDWxwB4bivZrsfvvVPP4iNW@gem.mutant.dev' do
+    gem 'mutant-license'
+  end
+
   gem 'capybara'
-  #gem 'mutant',  github: 'mbj/mutant', ref: '90d103dc323eded68a7e80439def069f18b5e990'
-  #gem 'mutant-rspec',  github: 'mbj/mutant', ref: '90d103dc323eded68a7e80439def069f18b5e990'
+  gem 'mutant'
+  gem 'mutant-rspec'
   gem 'selenium-webdriver'
   gem 'simplecov', require: false
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,6 +1,12 @@
 GEM
+  remote: https://oss:FwSfIZqXnuDWxwB4bivZrsfvvVPP4iNW@gem.mutant.dev/
+  specs:
+    mutant-license (0.1.1.2.3409332345164379413530821759471035288456.0)
+
+GEM
   remote: https://rubygems.org/
   specs:
+    abstract_type (0.0.7)
     actioncable (6.1.3.1)
       actionpack (= 6.1.3.1)
       activesupport (= 6.1.3.1)
@@ -74,6 +80,10 @@ GEM
       memoizable (~> 0.4.0)
     addressable (2.7.0)
       public_suffix (>= 2.0.2, < 5.0)
+    anima (0.3.2)
+      abstract_type (~> 0.0.7)
+      adamantium (~> 0.2)
+      equalizer (~> 0.0.11)
     arbre (1.4.0)
       activesupport (>= 3.0.0, < 6.2)
       ruby2_keywords (>= 0.0.2, < 1.0)
@@ -226,8 +236,32 @@ GEM
     mini_mime (1.0.3)
     mini_portile2 (2.5.0)
     minitest (5.14.4)
+    mprelude (0.1.0)
+      abstract_type (~> 0.0.7)
+      adamantium (~> 0.2.0)
+      concord (~> 0.1.5)
+      equalizer (~> 0.0.9)
+      ice_nine (~> 0.11.1)
+      procto (~> 0.0.2)
     msgpack (1.4.2)
     multipart-post (2.1.1)
+    mutant (0.9.4)
+      abstract_type (~> 0.0.7)
+      adamantium (~> 0.2.0)
+      anima (~> 0.3.1)
+      ast (~> 2.2)
+      concord (~> 0.1.5)
+      diff-lcs (~> 1.3)
+      equalizer (~> 0.0.9)
+      ice_nine (~> 0.11.1)
+      memoizable (~> 0.4.2)
+      mprelude (~> 0.1.0)
+      parser (~> 2.6.5)
+      procto (~> 0.0.2)
+      unparser (~> 0.4.6)
+    mutant-rspec (0.9.4)
+      mutant (~> 0.9.4)
+      rspec-core (>= 3.8.0, < 4.0.0)
     net-http-persistent (4.0.1)
       connection_pool (~> 2.2)
     nio4r (2.5.7)
@@ -415,6 +449,16 @@ GEM
     tzinfo (2.0.4)
       concurrent-ruby (~> 1.0)
     unicode-display_width (1.6.1)
+    unparser (0.4.9)
+      abstract_type (~> 0.0.7)
+      adamantium (~> 0.2.0)
+      anima (~> 0.3.1)
+      concord (~> 0.1.5)
+      diff-lcs (~> 1.3)
+      equalizer (~> 0.0.9)
+      mprelude (~> 0.1.0)
+      parser (>= 2.6.5)
+      procto (~> 0.0.2)
     vcr (6.0.0)
     warden (1.2.9)
       rack (>= 2.0.9)
@@ -462,6 +506,9 @@ DEPENDENCIES
   jbuilder
   listen
   mainstreet
+  mutant
+  mutant-license!
+  mutant-rspec
   pg
   procto
   pry-byebug


### PR DESCRIPTION
Adds OSS license key for mutant. This key is only useful for this repository, so no danger it exposing it in Gemfile (Mutant does the same](https://github.com/mbj/mutant/blob/master/Gemfile.shared#L4).