### PR TITLE
Remove WEBPACKER_DEV_SERVER_HOST env var

### DIFF
--- a/docker-compose.codespaces.yml
+++ b/docker-compose.codespaces.yml
@@ -22,7 +22,6 @@ services:
       - postgres
     command: tail -f /dev/null
     environment:
-        WEBPACKER_DEV_SERVER_HOST: webpacker
         SEED_ADMIN_EMAIL: ${SEED_ADMIN_EMAIL}
         SEED_ADMIN_PASSWORD: ${SEED_ADMIN_PASSWORD}
         SELENIUM_REMOTE_HOST: selenium


### PR DESCRIPTION
It no longer belongs in this configuration and is preventing webpack dev server from starting correctly in codespaces