### PR TITLE
Update need create notification message

### DIFF
--- a/app/lib/services/notifications/needs/message/create.rb
+++ b/app/lib/services/notifications/needs/message/create.rb
@@ -10,12 +10,11 @@ module Services
           include Rails.application.routes.url_helpers
           include StartAtHelper
 
-          delegate :start_at,
+          delegate :start_at, :office,
                    to: :need
 
           def message
-            "A new need starting #{starting_day} at #{start_time} has opened "\
-              "up at your local office! #{url}".freeze
+            "Your help is needed at the child welfare office (in #{office.name}). Click here to respond yes/no: #{url}"
           end
 
           private

--- a/spec/lib/services/notifications/needs/message/create_spec.rb
+++ b/spec/lib/services/notifications/needs/message/create_spec.rb
@@ -3,19 +3,17 @@
 require 'rails_helper'
 
 RSpec.describe Services::Notifications::Needs::Message::Create do
-  subject { described_class.new(need, notifier).call }
+  describe '#message' do
+    let(:object) { described_class.new(need) }
+    let(:need) { create(:need, start_at: starts) }
+    let(:starts) { Time.zone.now.tomorrow.change(hour: 12, minute: 0) }
+    let(:url) { "http://localhost:3000/needs/#{need.id}" }
 
-  let(:notifier) { double }
-  let(:need) do
-    create(:need, start_at: Date.parse('2019-05-23')).tap do |need|
-      need.update(shifts: Services::BuildNeedShifts.call(need))
+    it 'returns expected message for create event' do
+      result = object.message
+
+      expect(result)
+        .to eql("Your help is needed at the child welfare office (in #{need.office.name}). Click here to respond yes/no: #{url}")
     end
   end
-  let(:msg) do
-    'A new need starting Thu, May 23 at 12:00am has opened up at your local '\
-      "office! http://localhost:3000/needs/#{need.id}"
-  end
-  let(:volunteer) { build(:user, age_ranges: need.age_ranges) }
-  let(:social_worker) { build(:social_worker, age_ranges: need.age_ranges) }
-
 end


### PR DESCRIPTION
Per Sarah’s request:

> It doesn’t grab attention. People are ignoring the texts, and confused about which office they need to go to (in cases where they are signed up for more than one office)
> Should read: Your help is needed at the child welfare office (in ___[office name]). Click here to respond yes/no.

Also add specs (there were none).