### PR TITLE
Add check for existing need

### DIFF
--- a/app/javascript/components/NewNeedDatePicker/index.js
+++ b/app/javascript/components/NewNeedDatePicker/index.js
@@ -4,7 +4,7 @@ import DatePicker from 'react-datepicker'
 class AddNewNeedsPicker extends React.Component {
   state = {
     startDate: this.props.startAt ? new Date(this.props.startAt) : null,
-    disabled: !!this.props.startAt
+    disabled: !!this.props.exists
   }
 
 

--- a/app/views/needs/_form_fields.html.haml
+++ b/app/views/needs/_form_fields.html.haml
@@ -11,7 +11,7 @@
   %legend Start Date/Time
   .grid-x
     .cell
-      = react_component("NewNeedDatePicker/index", { startAt: f.object.start_at })
+      = react_component("NewNeedDatePicker/index", { startAt: f.object.start_at, exists: f.object.id.present? })
 %fieldset.fieldset
   %legend Expected Duration
   .grid-x.grid-margin-x


### PR DESCRIPTION
Fixes a bug when creating a new need with validation errors. Previously, if an error prevented the need from saving the date/time would not be editable. This fix checks to see if the need being created/edited exists and only allows modifying date/time if the need does not exist.