### PR TITLE
Bring back preferred_language_override

### DIFF
--- a/db/migrate/20211110172116_add_preferred_language_override_to_need.rb
+++ b/db/migrate/20211110172116_add_preferred_language_override_to_need.rb
@@ -1,0 +1,5 @@
+class AddPreferredLanguageOverrideToNeed < ActiveRecord::Migration[6.1]
+  def change
+    add_column :needs, :preferred_language_override, :boolean, default: false, null: false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_10_27_213316) do
+ActiveRecord::Schema.define(version: 2021_11_10_172116) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -129,7 +129,7 @@ ActiveRecord::Schema.define(version: 2021_10_27_213316) do
     t.bigint "race_id"
     t.text "notes"
     t.bigint "unavailable_user_ids", default: [], array: true
-    t.boolean "preferred_language_override", default: false
+    t.boolean "preferred_language_override", default: false, null: false
     t.index ["office_id"], name: "index_needs_on_office_id"
     t.index ["preferred_language_id"], name: "index_needs_on_preferred_language_id"
     t.index ["race_id"], name: "index_needs_on_race_id"
@@ -226,7 +226,7 @@ ActiveRecord::Schema.define(version: 2021_10_27_213316) do
     t.index ["invitation_token"], name: "index_users_on_invitation_token", unique: true
     t.index ["invitations_count"], name: "index_users_on_invitations_count"
     t.index ["invited_by_id"], name: "index_users_on_invited_by_id"
-    t.index ["invited_by_type", "invited_by_id"], name: "index_users_on_invited_by_type_and_invited_by_id"
+    t.index ["invited_by_type", "invited_by_id"], name: "index_users_on_invited_by"
     t.index ["reset_password_token"], name: "index_users_on_reset_password_token", unique: true
     t.index ["unlock_token"], name: "index_users_on_unlock_token", unique: true
   end


### PR DESCRIPTION
The migration was removed by mistake in a previous PR.