### PR TITLE
Add children to existing needs - take two

### DIFF
--- a/db/migrate/20220215192557_add_children_to_existing_needs_take_two.rb
+++ b/db/migrate/20220215192557_add_children_to_existing_needs_take_two.rb
@@ -1,0 +1,24 @@
+class AddChildrenToExistingNeedsTakeTwo < ActiveRecord::Migration[6.1]
+  def up
+    Need.includes(:age_ranges).find_each do |need|
+      range_i = 0
+      age_ranges = need.age_ranges
+      need.read_attribute(:number_of_children).times do
+        j = age_ranges[range_i]
+        need.children.create!(
+          age: rand(j.min..j.max),
+          sex: rand(0..1),
+          notes: "Child automatically created from migration"
+        )
+        range_i += 1
+        if range_i > age_ranges.size - 1
+          range_i = 0
+        end
+      end
+    end
+  end
+
+  def down
+    raise ActiveRecord::IrreversibleMigration
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_11_10_172116) do
+ActiveRecord::Schema.define(version: 2022_02_15_192557) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"


### PR DESCRIPTION
The previous migration called `number_of_children`, which was redefined to count Child records. This effectively ensured that the migration had no effect.